### PR TITLE
fix(sync): include merge base in live note modifications

### DIFF
--- a/internal/sync/note_modify_basehash_test.go
+++ b/internal/sync/note_modify_basehash_test.go
@@ -1,0 +1,150 @@
+package sync
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/erichll/go-fast-note-sync/internal/local"
+	"github.com/erichll/go-fast-note-sync/internal/state"
+)
+
+func TestNoteModifyPayloadBaseHash(t *testing.T) {
+	t.Run("includes baseHash when file exists in FileHashMap", func(t *testing.T) {
+		svc, conn, _ := newLocalEventService(t)
+		svc.cfg.SyncEnabled = true
+		svc.cfg.ManualSyncEnabled = false
+		svc.cfg.ReadOnlySyncEnabled = false
+		svc.st.IsInitSync = false
+		svc.isSyncing = false
+		relPath := "notes/test.md"
+		writeVaultFile(t, svc.cfg.VaultPath, relPath, "new content")
+
+		svc.st.FileHashMap[relPath] = state.FileHashEntry{
+			Hash:  "old-base-hash",
+			MTime: 123456789,
+			Size:  10,
+		}
+
+		got := svc.HandleLocalModify(local.PathEvent{Path: relPath, IsDir: false})
+		if !got.Attempted || got.Err != nil {
+			t.Fatalf("HandleLocalModify result = %+v, want attempted success", got)
+		}
+
+		if len(conn.written) == 0 {
+			t.Fatal("expected websocket write")
+		}
+
+		action, payloadJSON, ok := parseWSMessage(t, conn.written[0])
+		if !ok || action != "NoteModify" {
+			t.Fatalf("action = %s, want NoteModify", action)
+		}
+
+		var payload map[string]interface{}
+		if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+			t.Fatalf("json unmarshal failed: %v", err)
+		}
+
+		if baseHash, ok := payload["baseHash"].(string); !ok || baseHash != "old-base-hash" {
+			t.Errorf("baseHash = %v, want %q", payload["baseHash"], "old-base-hash")
+		}
+		if missing, ok := payload["baseHashMissing"].(bool); ok && missing {
+			t.Errorf("baseHashMissing = %v, want false or absent", payload["baseHashMissing"])
+		}
+	})
+
+	t.Run("sets baseHashMissing true when file is absent in FileHashMap", func(t *testing.T) {
+		svc, conn, _ := newLocalEventService(t)
+		svc.cfg.SyncEnabled = true
+		svc.cfg.ManualSyncEnabled = false
+		svc.cfg.ReadOnlySyncEnabled = false
+		svc.st.IsInitSync = false
+		svc.isSyncing = false
+		relPath := "notes/new.md"
+		writeVaultFile(t, svc.cfg.VaultPath, relPath, "new content")
+
+		got := svc.HandleLocalModify(local.PathEvent{Path: relPath, IsDir: false})
+		if !got.Attempted || got.Err != nil {
+			t.Fatalf("HandleLocalModify result = %+v, want attempted success", got)
+		}
+
+		if len(conn.written) == 0 {
+			t.Fatal("expected websocket write")
+		}
+
+		action, payloadJSON, ok := parseWSMessage(t, conn.written[0])
+		if !ok || action != "NoteModify" {
+			t.Fatalf("action = %s, want NoteModify", action)
+		}
+
+		var payload map[string]interface{}
+		if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+			t.Fatalf("json unmarshal failed: %v", err)
+		}
+
+		if missing, ok := payload["baseHashMissing"].(bool); !ok || !missing {
+			t.Errorf("baseHashMissing = %v, want true", payload["baseHashMissing"])
+		}
+		if baseHash, ok := payload["baseHash"]; ok && baseHash != nil && baseHash != "" {
+			t.Errorf("baseHash = %v, want absent/empty", baseHash)
+		}
+	})
+
+	t.Run("SettingModify does not include baseHash or baseHashMissing", func(t *testing.T) {
+		svc, conn, _ := newLocalEventService(t)
+		svc.cfg.SyncEnabled = true
+		svc.cfg.ManualSyncEnabled = false
+		svc.cfg.ReadOnlySyncEnabled = false
+		svc.cfg.ConfigSyncEnabled = true
+		svc.st.IsInitSync = false
+		svc.isSyncing = false
+		relPath := ".obsidian/app.json"
+		writeVaultFile(t, svc.cfg.VaultPath, relPath, `{"theme":"dark"}`)
+
+		svc.st.ConfigHashMap[relPath] = state.FileHashEntry{
+			Hash:  "config-base-hash",
+			MTime: 123456789,
+			Size:  15,
+		}
+
+		got := svc.HandleLocalModify(local.PathEvent{Path: relPath, IsDir: false})
+		if !got.Attempted || got.Err != nil {
+			t.Fatalf("HandleLocalModify result = %+v, want attempted success", got)
+		}
+
+		if len(conn.written) == 0 {
+			t.Fatal("expected websocket write")
+		}
+
+		action, payloadJSON, ok := parseWSMessage(t, conn.written[0])
+		if !ok || action != "SettingModify" {
+			t.Fatalf("action = %s, want SettingModify", action)
+		}
+
+		var payload map[string]interface{}
+		if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+			t.Fatalf("json unmarshal failed: %v", err)
+		}
+
+		if _, ok := payload["baseHash"]; ok {
+			t.Errorf("SettingModify should not have baseHash, got %v", payload["baseHash"])
+		}
+		if _, ok := payload["baseHashMissing"]; ok {
+			t.Errorf("SettingModify should not have baseHashMissing, got %v", payload["baseHashMissing"])
+		}
+	})
+}
+
+func parseWSMessage(t *testing.T, raw string) (action, payloadJSON string, ok bool) {
+	t.Helper()
+	var actionStr string
+	if idx := len(raw); idx > 0 {
+		for i, ch := range raw {
+			if ch == '|' {
+				actionStr = raw[:i]
+				payloadJSON = raw[i+1:]
+				return actionStr, payloadJSON, true
+			}
+		}
+	}
+	return "", "", false
+}

--- a/internal/sync/runtime_helpers.go
+++ b/internal/sync/runtime_helpers.go
@@ -412,6 +412,15 @@ func (s *SyncService) sendFileContentModify(action string, rp resolvedPath, pend
 		"mtime":       info.ModTime().UnixMilli(),
 		"ctime":       info.ModTime().UnixMilli(),
 	}
+	if action == "NoteModify" {
+		s.mu.Lock()
+		if entry, ok := s.st.FileHashMap[rp.Rel]; ok && entry.Hash != "" {
+			payload["baseHash"] = entry.Hash
+		} else {
+			payload["baseHashMissing"] = true
+		}
+		s.mu.Unlock()
+	}
 	s.concurrency.WaitForSlot(rp.Rel, false, 0)
 	if err := s.Send(action, payload); err != nil {
 		s.concurrency.ReleaseSlot(rp.Rel)


### PR DESCRIPTION
## Summary
- attach the last synchronized hash as baseHash to live NoteModify payloads
- send baseHashMissing when no synchronized baseline exists
- leave SettingModify payloads and pending/ack behavior unchanged

## Why
Startup scans already send merge-base metadata, but live filesystem events do not. Without it, the server cannot perform the same three-way merge for edits made after startup.

## Tests
- go test -count=1 ./internal/sync
- go vet ./internal/sync
- go build ./...
- composed with the atomic-write and protective-delete patches in a disposable integration branch