### PR TITLE
fix(sync): atomically replace downloaded notes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.5
 require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/sys v0.29.0
 )
 
 require (
@@ -20,6 +21,5 @@ require (
 	github.com/spf13/viper v1.21.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 )

--- a/internal/sync/atomic_write.go
+++ b/internal/sync/atomic_write.go
@@ -1,0 +1,54 @@
+package sync
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+var replaceFile = replaceFileImpl
+
+func atomicWriteFile(destination string, content []byte) (err error) {
+	mode := os.FileMode(0o644)
+	if info, statErr := os.Stat(destination); statErr == nil {
+		mode = info.Mode().Perm()
+	} else if !os.IsNotExist(statErr) {
+		return fmt.Errorf("stat destination: %w", statErr)
+	}
+
+	temp, err := os.CreateTemp(filepath.Dir(destination), "."+filepath.Base(destination)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temporary file: %w", err)
+	}
+	tempPath := temp.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tempPath)
+		}
+		if err != nil {
+			err = fmt.Errorf("write %q: %w", destination, err)
+		}
+	}()
+
+	if err := temp.Chmod(mode); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if _, err := temp.Write(content); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Sync(); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	if err := replaceFile(tempPath, destination); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}

--- a/internal/sync/handlers_test.go
+++ b/internal/sync/handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -582,6 +583,111 @@ func TestHandleNoteSyncModify_WritesFileAndRejectsTraversal(t *testing.T) {
 	handleNoteSyncModify(bad, svc)
 	if _, err := os.Stat(filepath.Join(filepath.Dir(dir), "evil.md")); !os.IsNotExist(err) {
 		t.Fatalf("traversal path should not be written, stat err=%v", err)
+	}
+}
+
+func TestAtomicWriteFile_ReplacementFailurePreservesDestination(t *testing.T) {
+	dir := t.TempDir()
+	destination := filepath.Join(dir, "note.md")
+	original := []byte("original content")
+	if err := os.WriteFile(destination, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	originalReplaceFile := replaceFile
+	replaceFile = func(_, _ string) error {
+		return os.ErrPermission
+	}
+	t.Cleanup(func() { replaceFile = originalReplaceFile })
+
+	if err := atomicWriteFile(destination, []byte("replacement content")); err == nil {
+		t.Fatal("atomicWriteFile should report replacement failure")
+	}
+	got, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("destination = %q, want %q", got, original)
+	}
+}
+
+func TestAtomicWriteFile_ReplacesDestinationAndCleansTemporaryFile(t *testing.T) {
+	dir := t.TempDir()
+	destination := filepath.Join(dir, "note.md")
+	if err := os.WriteFile(destination, []byte("original content"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := atomicWriteFile(destination, []byte("replacement content")); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "replacement content" {
+		t.Fatalf("destination = %q, want replacement content", got)
+	}
+	info, err := os.Stat(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS != "windows" {
+		if got, want := info.Mode().Perm(), os.FileMode(0o640); got != want {
+			t.Fatalf("destination mode = %o, want %o", got, want)
+		}
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "note.md" {
+		t.Fatalf("directory entries = %#v, want only note.md", entries)
+	}
+}
+
+func TestHandleNoteSyncModify_ReplacementFailurePreservesState(t *testing.T) {
+	dir := t.TempDir()
+	destination := filepath.Join(dir, "note.md")
+	if err := os.WriteFile(destination, []byte("original content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{VaultPath: dir}
+	svc := newTestService(cfg, nil, "")
+	svc.st.NoteSyncTime = 7
+	svc.st.FileHashMap["note.md"] = state.FileHashEntry{Hash: "old-hash"}
+	svc.pendingNoteModifies["note.md"] = "pending-hash"
+	svc.st.PendingNoteModifies["note.md"] = "pending-hash"
+
+	originalReplaceFile := replaceFile
+	replaceFile = func(_, _ string) error { return os.ErrPermission }
+	t.Cleanup(func() { replaceFile = originalReplaceFile })
+
+	content := "replacement content"
+	msg, _ := json.Marshal(receiveContentMessage{
+		Path:        "note.md",
+		Content:     content,
+		ContentHash: h.Content([]byte(content)),
+		LastTime:    99,
+	})
+	handleNoteSyncModify(msg, svc)
+
+	got, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "original content" {
+		t.Fatalf("destination = %q, want original content", got)
+	}
+	svc.mu.Lock()
+	entry := svc.st.FileHashMap["note.md"]
+	pending, pendingOK := svc.pendingNoteModifies["note.md"]
+	statePending, statePendingOK := svc.st.PendingNoteModifies["note.md"]
+	lastTime := svc.st.NoteSyncTime
+	svc.mu.Unlock()
+	if entry.Hash != "old-hash" || !pendingOK || pending != "pending-hash" || !statePendingOK || statePending != "pending-hash" || lastTime != 7 {
+		t.Fatalf("state changed after replacement failure: entry=%+v pending=%q/%v statePending=%q/%v lastTime=%d", entry, pending, pendingOK, statePending, statePendingOK, lastTime)
 	}
 }
 

--- a/internal/sync/note_sync.go
+++ b/internal/sync/note_sync.go
@@ -68,7 +68,6 @@ func handleNoteSyncModify(data json.RawMessage, s *SyncService) {
 		return
 	}
 	defer s.incrementCompleted("note")
-	s.updateSyncTime("note", msg.LastTime)
 
 	rp, err := s.resolveVaultPath(msg.Path)
 	if err != nil || !strings.HasSuffix(strings.ToLower(msg.Path), ".md") || s.isVaultFileExcluded(msg.Path) {
@@ -84,11 +83,12 @@ func handleNoteSyncModify(data json.RawMessage, s *SyncService) {
 		log.Printf("[handler] NoteSyncModify mkdir %q: %v", rp.Rel, err)
 		return
 	}
-	s.addIgnoredFile(rp.Rel)
-	if err := os.WriteFile(rp.Abs, []byte(msg.Content), 0o644); err != nil {
+	if err := atomicWriteFile(rp.Abs, []byte(msg.Content)); err != nil {
 		log.Printf("[handler] NoteSyncModify write %q: %v", rp.Rel, err)
 		return
 	}
+	s.updateSyncTime("note", msg.LastTime)
+	s.addIgnoredFile(rp.Rel)
 	mtime := msg.MTime
 	if mtime > 0 {
 		tm := unixMilli(mtime)

--- a/internal/sync/replace_file_unix.go
+++ b/internal/sync/replace_file_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package sync
+
+import "os"
+
+func replaceFileImpl(source, destination string) error {
+	return os.Rename(source, destination)
+}

--- a/internal/sync/replace_file_windows.go
+++ b/internal/sync/replace_file_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package sync
+
+import "golang.org/x/sys/windows"
+
+func replaceFileImpl(source, destination string) error {
+	sourcePtr, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	destinationPtr, err := windows.UTF16PtrFromString(destination)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(sourcePtr, destinationPtr, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH)
+}


### PR DESCRIPTION
## Summary
- write downloaded notes to a same-directory temporary file
- sync and close before atomically replacing the destination
- use MoveFileEx with replace-existing/write-through on Windows
- preserve destination bytes and pending state when replacement fails

## Why
NoteSyncModify currently writes directly to the destination. A crash or write failure can leave a partial note.

## Tests
- go test -count=1 ./internal/sync
- go vet ./internal/sync
- go build ./...
- Windows-native focused tests
- composed with the live-base-hash and protective-delete patches in a disposable integration branch