### PR TITLE
fix(sync): match server 3.6 protocol

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -50,6 +50,7 @@ type syncDaemon interface {
 	local.Handler
 	Connect()
 	SyncComplete() <-chan struct{}
+	SyncError() error
 }
 
 type localWatcher interface {
@@ -206,6 +207,9 @@ func newSyncCmd() *cobra.Command {
 			defer cancel()
 			select {
 			case <-svc.SyncComplete():
+				if err := svc.SyncError(); err != nil {
+					return err
+				}
 				fmt.Fprintln(cmd.OutOrStdout(), "Sync complete.")
 				return nil
 			case <-ctx.Done():

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -57,7 +58,7 @@ func TestStartLoadStateError(t *testing.T) {
 		t.Fatalf("init-config: %v", err)
 	}
 	data, _ := os.ReadFile(cfgPath)
-	updated := strings.Replace(string(data), "state_file: \"\"", "state_file: \""+statePath+"\"", 1)
+	updated := strings.Replace(string(data), "state_file: \"\"", "state_file: "+strconv.Quote(statePath), 1)
 	if err := os.WriteFile(cfgPath, []byte(updated), 0o600); err != nil {
 		t.Fatalf("rewrite config: %v", err)
 	}
@@ -90,7 +91,7 @@ func TestStartHappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read config: %v", err)
 	}
-	updated := strings.Replace(string(data), "state_file: \"\"", "state_file: \""+statePath+"\"", 1)
+	updated := strings.Replace(string(data), "state_file: \"\"", "state_file: "+strconv.Quote(statePath), 1)
 	if err := os.WriteFile(cfgPath, []byte(updated), 0o600); err != nil {
 		t.Fatalf("rewrite config: %v", err)
 	}
@@ -108,6 +109,7 @@ func TestStartHappyPath(t *testing.T) {
 type fakeDaemon struct {
 	connected  bool
 	syncDoneCh chan struct{}
+	syncErr    error
 }
 
 func (f *fakeDaemon) Connect() {
@@ -119,6 +121,10 @@ func (f *fakeDaemon) SyncComplete() <-chan struct{} {
 		f.syncDoneCh = make(chan struct{})
 	}
 	return f.syncDoneCh
+}
+
+func (f *fakeDaemon) SyncError() error {
+	return f.syncErr
 }
 
 func (f *fakeDaemon) ShouldWatchDir(string) bool {
@@ -175,8 +181,8 @@ func TestStartWatcherGatedBySyncEnabledAndVaultPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	updated := string(data)
-	updated = strings.Replace(updated, "state_file: \"\"", "state_file: \""+statePath+"\"", 1)
-	updated = strings.Replace(updated, "vault_path: \"\"", "vault_path: \""+vaultPath+"\"", 1)
+	updated = strings.Replace(updated, "state_file: \"\"", "state_file: "+strconv.Quote(statePath), 1)
+	updated = strings.Replace(updated, "vault_path: \"\"", "vault_path: "+strconv.Quote(vaultPath), 1)
 	if err := os.WriteFile(cfgPath, []byte(updated), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -267,7 +273,7 @@ func TestStatusCmd(t *testing.T) {
 					t.Fatalf("init-config: %v", err)
 				}
 				data, _ := os.ReadFile(cfgPath)
-				updated := strings.Replace(string(data), "state_file: \"\"", "state_file: \""+statePath+"\"", 1)
+				updated := strings.Replace(string(data), "state_file: \"\"", "state_file: "+strconv.Quote(statePath), 1)
 				if err := os.WriteFile(cfgPath, []byte(updated), 0o600); err != nil {
 					t.Fatalf("rewrite config: %v", err)
 				}
@@ -349,7 +355,7 @@ func TestSyncCmd_Timeout(t *testing.T) {
 		t.Fatalf("init-config: %v", err)
 	}
 	data, _ := os.ReadFile(cfgPath)
-	updated := strings.Replace(string(data), "state_file: \"\"", "state_file: \""+statePath+"\"", 1)
+	updated := strings.Replace(string(data), "state_file: \"\"", "state_file: "+strconv.Quote(statePath), 1)
 	if err := os.WriteFile(cfgPath, []byte(updated), 0o600); err != nil {
 		t.Fatalf("rewrite config: %v", err)
 	}
@@ -378,7 +384,7 @@ func TestSyncCmd_Success(t *testing.T) {
 		t.Fatalf("init-config: %v", err)
 	}
 	data, _ := os.ReadFile(cfgPath)
-	updated := strings.Replace(string(data), "state_file: \"\"", "state_file: \""+statePath+"\"", 1)
+	updated := strings.Replace(string(data), "state_file: \"\"", "state_file: "+strconv.Quote(statePath), 1)
 	if err := os.WriteFile(cfgPath, []byte(updated), 0o600); err != nil {
 		t.Fatalf("rewrite config: %v", err)
 	}

--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -1,11 +1,16 @@
 package hash
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
+	"strconv"
+	"unicode/utf16"
+)
+
+const (
+	fullFileHashLimit = 10 * 1024 * 1024
+	fileHashSample    = 5 * 1024 * 1024
 )
 
 type CacheEntry struct {
@@ -15,12 +20,35 @@ type CacheEntry struct {
 }
 
 func Content(data []byte) string {
-	sum := sha256.Sum256(data)
-	return hex.EncodeToString(sum[:])
+	var sum int32
+	for _, value := range data {
+		sum = sum*31 + int32(value)
+	}
+	return strconv.FormatInt(int64(sum), 10)
 }
 
-func Path(p string) string {
-	return Content([]byte(p))
+func FileContent(data []byte) string {
+	if len(data) <= fullFileHashLimit {
+		return Content(data)
+	}
+	middle := len(data)/2 - fileHashSample/2
+	sample := make([]byte, 0, fileHashSample*3)
+	sample = append(sample, data[:fileHashSample]...)
+	sample = append(sample, data[middle:middle+fileHashSample]...)
+	sample = append(sample, data[len(data)-fileHashSample:]...)
+	return Content(sample)
+}
+
+func Text(value string) string {
+	var sum int32
+	for _, codeUnit := range utf16.Encode([]rune(value)) {
+		sum = sum*31 + int32(codeUnit)
+	}
+	return strconv.FormatInt(int64(sum), 10)
+}
+
+func Path(path string) string {
+	return Text(path)
 }
 
 func File(path string) (hash string, mtime int64, size int64, err error) {
@@ -35,17 +63,54 @@ func File(path string) (hash string, mtime int64, size int64, err error) {
 	}
 	defer f.Close()
 
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
+	var data []byte
+	if info.Size() <= fullFileHashLimit {
+		data, err = io.ReadAll(f)
+	} else {
+		data, err = readFileSamples(f, info.Size())
+	}
+	if err != nil {
 		return "", 0, 0, fmt.Errorf("hash %s: %w", path, err)
 	}
 
-	return hex.EncodeToString(h.Sum(nil)), info.ModTime().UnixMilli(), info.Size(), nil
+	return Content(data), info.ModTime().UnixMilli(), info.Size(), nil
+}
+
+func TextFile(path string) (hash string, mtime int64, size int64, err error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", 0, 0, fmt.Errorf("stat %s: %w", path, err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", 0, 0, fmt.Errorf("read %s: %w", path, err)
+	}
+	return Text(string(data)), info.ModTime().UnixMilli(), info.Size(), nil
+}
+
+func readFileSamples(file *os.File, size int64) ([]byte, error) {
+	sample := make([]byte, fileHashSample*3)
+	middle := size/2 - fileHashSample/2
+	offsets := []int64{0, middle, size - fileHashSample}
+	for index, offset := range offsets {
+		if _, err := file.ReadAt(sample[index*fileHashSample:(index+1)*fileHashSample], offset); err != nil && err != io.EOF {
+			return nil, err
+		}
+	}
+	return sample, nil
 }
 
 // FileCached returns the hash from cache if mtime and size match; otherwise recomputes.
 // Returns (hash, fromCache, error).
 func FileCached(path string, entry *CacheEntry) (string, bool, error) {
+	return cached(path, entry, File)
+}
+
+func TextFileCached(path string, entry *CacheEntry) (string, bool, error) {
+	return cached(path, entry, TextFile)
+}
+
+func cached(path string, entry *CacheEntry, calculate func(string) (string, int64, int64, error)) (string, bool, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return "", false, fmt.Errorf("stat %s: %w", path, err)
@@ -58,7 +123,7 @@ func FileCached(path string, entry *CacheEntry) (string, bool, error) {
 		return entry.Hash, true, nil
 	}
 
-	h, _, _, err := File(path)
+	h, _, _, err := calculate(path)
 	if err != nil {
 		return "", false, err
 	}

--- a/internal/hash/hash_test.go
+++ b/internal/hash/hash_test.go
@@ -8,8 +8,7 @@ import (
 
 func TestContent(t *testing.T) {
 	h := Content([]byte("hello"))
-	// SHA256("hello") = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
-	want := "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+	want := "99162322"
 	if h != want {
 		t.Errorf("Content(hello): want %s, got %s", want, h)
 	}
@@ -17,10 +16,15 @@ func TestContent(t *testing.T) {
 
 func TestContentEmpty(t *testing.T) {
 	h := Content([]byte{})
-	// SHA256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-	want := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	want := "0"
 	if h != want {
 		t.Errorf("Content(empty): want %s, got %s", want, h)
+	}
+}
+
+func TestTextUsesJavaScriptUTF16CodeUnits(t *testing.T) {
+	if got, want := Text("A😀"), "1835364"; got != want {
+		t.Errorf("Text(A😀): want %s, got %s", want, got)
 	}
 }
 
@@ -34,8 +38,8 @@ func TestPath(t *testing.T) {
 	if h1 == h3 {
 		t.Error("different paths should produce different hashes")
 	}
-	if len(h1) != 64 {
-		t.Errorf("expected 64 hex chars, got %d", len(h1))
+	if h1 != Text("notes/foo.md") {
+		t.Errorf("Path should use text hashing: got %s", h1)
 	}
 }
 
@@ -59,6 +63,40 @@ func TestFile(t *testing.T) {
 	}
 	if mtime == 0 {
 		t.Error("mtime should be non-zero")
+	}
+}
+
+func TestTextFileUsesUTF16Hash(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "unicode.md")
+	if err := os.WriteFile(path, []byte("A😀"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, _, _, err := TextFile(path)
+	if err != nil {
+		t.Fatalf("TextFile: %v", err)
+	}
+	if want := Text("A😀"); got != want {
+		t.Errorf("TextFile: want %s, got %s", want, got)
+	}
+	if got == Content([]byte("A😀")) {
+		t.Error("text and byte hashes should differ for non-ASCII content")
+	}
+}
+
+func TestFileContentSamplesLargeData(t *testing.T) {
+	data := make([]byte, fullFileHashLimit+1)
+	for index := range data {
+		data[index] = byte(index)
+	}
+	middle := len(data)/2 - fileHashSample/2
+	sample := make([]byte, 0, fileHashSample*3)
+	sample = append(sample, data[:fileHashSample]...)
+	sample = append(sample, data[middle:middle+fileHashSample]...)
+	sample = append(sample, data[len(data)-fileHashSample:]...)
+	if got, want := FileContent(data), Content(sample); got != want {
+		t.Errorf("FileContent(large): want %s, got %s", want, got)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 )
+
+var writeMu sync.Mutex
 
 type FileHashEntry struct {
 	Hash  string `json:"hash"`
@@ -111,6 +114,9 @@ func Save(path string, s *State) error {
 // WriteFileAtomic writes data to path through a unique temporary file in the
 // same directory, then renames it into place.
 func WriteFileAtomic(path string, data []byte) error {
+	writeMu.Lock()
+	defer writeMu.Unlock()
+
 	if path == "" {
 		return fmt.Errorf("state path is empty")
 	}

--- a/internal/sync/client.go
+++ b/internal/sync/client.go
@@ -87,6 +87,18 @@ type SyncTaskCounter struct {
 	Completed     int
 }
 
+type syncPage struct {
+	TotalCount     int
+	CompletedCount int
+	IsLast         bool
+}
+
+type syncPageTracker struct {
+	Context      string
+	AckWatermark int
+	Pages        map[int]*syncPage
+}
+
 // SyncService manages the WebSocket connection lifecycle and sync state.
 type SyncService struct {
 	cfg       *config.Config
@@ -153,6 +165,7 @@ type SyncService struct {
 	fileSyncEnd   bool
 	configSyncEnd bool
 	folderSyncEnd bool
+	syncPages     map[string]*syncPageTracker
 
 	// echo suppression / scan caches
 	lastSyncMtime       map[string]int64
@@ -169,6 +182,7 @@ type SyncService struct {
 
 	syncDoneCh   chan struct{}
 	syncDoneOnce stdsync.Once
+	syncErr      error
 }
 
 // NewSyncService creates a SyncService with production defaults.
@@ -206,6 +220,7 @@ func NewSyncService(cfg *config.Config, st *state.State, statePath, version stri
 		scannedConfigHashes:      make(map[string]state.FileHashEntry),
 		concurrency:              NewConcurrencyManager(cfg),
 		pathLocks:                make(map[string]chan struct{}),
+		syncPages:                make(map[string]*syncPageTracker),
 		syncDoneCh:               make(chan struct{}),
 	}
 	if cfg.SyncTimeoutSeconds > 0 {
@@ -218,6 +233,12 @@ func NewSyncService(cfg *config.Config, st *state.State, statePath, version stri
 // SyncComplete returns a channel that is closed once the first sync round completes.
 func (s *SyncService) SyncComplete() <-chan struct{} {
 	return s.syncDoneCh
+}
+
+func (s *SyncService) SyncError() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.syncErr
 }
 
 // buildWSURL constructs the WebSocket connection URL.

--- a/internal/sync/config_sync.go
+++ b/internal/sync/config_sync.go
@@ -65,7 +65,7 @@ func handleSettingSyncModify(data json.RawMessage, s *SyncService) {
 		s.incrementCompleted("config")
 		return
 	}
-	defer s.incrementCompleted("config")
+	defer s.incrementCompletedPage("config", msg.PageIndex)
 	if isLocalStorageSettingPath(msg.Path) || isSensitivePluginConfigPath(msg.Path) {
 		log.Printf("[handler] SettingSyncModify skip excluded config path %q", msg.Path)
 		return
@@ -97,7 +97,7 @@ func handleSettingSyncModify(data json.RawMessage, s *SyncService) {
 		return
 	}
 	if entry.Hash == "" {
-		entry.Hash = h.Content([]byte(msg.Content))
+		entry.Hash = h.Text(msg.Content)
 	}
 	s.mu.Lock()
 	s.st.ConfigHashMap[rp.Rel] = entry
@@ -112,25 +112,25 @@ func handleSettingSyncNeedUpload(data json.RawMessage, s *SyncService) {
 	var msg receivePathMessage
 	if err := json.Unmarshal(data, &msg); err != nil {
 		log.Printf("[handler] SettingSyncNeedUpload parse: %v", err)
-		s.incrementCompleted("config")
+		s.incrementCompletedPage("config", msg.PageIndex)
 		return
 	}
 	if isLocalStorageSettingPath(msg.Path) || isSensitivePluginConfigPath(msg.Path) {
 		log.Printf("[handler] SettingSyncNeedUpload skip excluded config path %q", msg.Path)
-		s.incrementCompleted("config")
+		s.incrementCompletedPage("config", msg.PageIndex)
 		return
 	}
 	s.updateSyncTime("config", msg.LastTime)
 	rp, err := s.resolveVaultPath(msg.Path)
 	if err != nil || s.cfg.ReadOnlySyncEnabled || !s.isConfigSyncPathAllowed(rp.Rel) {
-		s.incrementCompleted("config")
+		s.incrementCompletedPage("config", msg.PageIndex)
 		return
 	}
 	if _, err := os.Stat(rp.Abs); err != nil {
-		s.incrementCompleted("config")
+		s.incrementCompletedPage("config", msg.PageIndex)
 		return
 	}
-	if err := s.sendFileContentModify("SettingModify", rp, s.setPendingConfigModify, func() { s.incrementCompleted("config") }); err != nil {
+	if err := s.sendFileContentModify("SettingModify", rp, s.setPendingConfigModify, func() { s.incrementCompletedPage("config", msg.PageIndex) }); err != nil {
 		log.Printf("[handler] SettingSyncNeedUpload send %q: %v", rp.Rel, err)
 	}
 }
@@ -142,7 +142,7 @@ func handleSettingSyncMtime(data json.RawMessage, s *SyncService) {
 		s.incrementCompleted("config")
 		return
 	}
-	defer s.incrementCompleted("config")
+	defer s.incrementCompletedPage("config", msg.PageIndex)
 	if isLocalStorageSettingPath(msg.Path) || isSensitivePluginConfigPath(msg.Path) {
 		return
 	}
@@ -181,7 +181,7 @@ func handleSettingSyncDelete(data json.RawMessage, s *SyncService) {
 		s.incrementCompleted("config")
 		return
 	}
-	defer s.incrementCompleted("config")
+	defer s.incrementCompletedPage("config", msg.PageIndex)
 	if isLocalStorageSettingPath(msg.Path) || isSensitivePluginConfigPath(msg.Path) {
 		return
 	}
@@ -206,11 +206,13 @@ func handleSettingSyncDelete(data json.RawMessage, s *SyncService) {
 	s.saveStateLog("SettingSyncDelete")
 }
 
-func handleSettingSyncClear(_ json.RawMessage, s *SyncService) {
+func handleSettingSyncClear(data json.RawMessage, s *SyncService) {
+	var msg receivePathMessage
+	_ = json.Unmarshal(data, &msg)
 	s.mu.Lock()
 	s.st.ConfigSyncTime = 0
-	s.configSyncTasks.Completed++
 	s.mu.Unlock()
+	s.incrementCompletedPage("config", msg.PageIndex)
 	s.saveStateLog("SettingSyncClear")
 }
 

--- a/internal/sync/dispatcher.go
+++ b/internal/sync/dispatcher.go
@@ -8,11 +8,13 @@ import (
 
 // Envelope is the common server response structure for all text messages.
 type Envelope struct {
-	Code    int             `json:"code"`
-	Message string          `json:"message"`
-	Details string          `json:"details"`
-	Data    json.RawMessage `json:"data"`
-	Vault   string          `json:"vault"`
+	Code      int             `json:"code"`
+	Message   string          `json:"message"`
+	Details   string          `json:"details"`
+	Data      json.RawMessage `json:"data"`
+	Vault     string          `json:"vault"`
+	Context   string          `json:"context"`
+	PageIndex int             `json:"pageIndex"`
 }
 
 // parseTextMessage splits a raw WebSocket text frame into action and envelope.
@@ -68,12 +70,113 @@ func (s *SyncService) dispatchText(raw string) {
 		log.Printf("[ws] vault mismatch: got %q, want %q, skipping %q", env.Vault, s.cfg.Vault, action)
 		return
 	}
+	if module, ok := syncPageModule(action); ok {
+		s.handleSyncPage(module, env)
+		return
+	}
 
 	handler, ok := s.receiveHandlers[action]
 	if !ok {
 		return
 	}
-	handler(env.Data, s)
+	data := env.Data
+	if module, ok := syncWorkModule(action); ok {
+		if pageIndex, found := s.resolveSyncPageIndex(module, env.PageIndex, data); found {
+			data = withPageIndex(data, pageIndex)
+		}
+	}
+	handler(data, s)
+	if module, ok := syncEndModule(action); ok {
+		s.startSyncPaging(module, env.Context)
+	}
+}
+
+func (s *SyncService) resolveSyncPageIndex(module string, envelopePageIndex int, data json.RawMessage) (int, bool) {
+	var detail struct {
+		PageIndex *int `json:"pageIndex"`
+	}
+	_ = json.Unmarshal(data, &detail)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	tracker := s.syncPages[module]
+	if tracker == nil {
+		return 0, false
+	}
+	if detail.PageIndex != nil && tracker.Pages[*detail.PageIndex] != nil {
+		return *detail.PageIndex, true
+	}
+	if tracker.Pages[envelopePageIndex] != nil {
+		return envelopePageIndex, true
+	}
+	if len(tracker.Pages) != 1 {
+		return 0, false
+	}
+	for pageIndex := range tracker.Pages {
+		return pageIndex, true
+	}
+	return 0, false
+}
+
+func withPageIndex(data json.RawMessage, pageIndex int) json.RawMessage {
+	var payload map[string]interface{}
+	if err := json.Unmarshal(data, &payload); err != nil || payload == nil {
+		return data
+	}
+	if _, exists := payload["pageIndex"]; exists {
+		return data
+	}
+	payload["pageIndex"] = pageIndex
+	updated, err := json.Marshal(payload)
+	if err != nil {
+		return data
+	}
+	return updated
+}
+
+func syncWorkModule(action string) (string, bool) {
+	switch action {
+	case "NoteSyncModify", "NoteSyncDelete", "NoteSyncNeedPush", "NoteSyncMtime", "NoteSyncRename":
+		return "note", true
+	case "FileSyncUpdate", "FileUpload", "FileSyncDelete", "FileSyncMtime", "FileSyncRename":
+		return "file", true
+	case "SettingSyncModify", "SettingSyncNeedUpload", "SettingSyncMtime", "SettingSyncDelete", "SettingSyncClear":
+		return "config", true
+	case "FolderSyncModify", "FolderSyncDelete", "FolderSyncRename":
+		return "folder", true
+	default:
+		return "", false
+	}
+}
+
+func syncPageModule(action string) (string, bool) {
+	switch action {
+	case "NoteSyncPage":
+		return "note", true
+	case "FileSyncPage":
+		return "file", true
+	case "SettingSyncPage":
+		return "config", true
+	case "FolderSyncPage":
+		return "folder", true
+	default:
+		return "", false
+	}
+}
+
+func syncEndModule(action string) (string, bool) {
+	switch action {
+	case "NoteSyncEnd":
+		return "note", true
+	case "FileSyncEnd":
+		return "file", true
+	case "SettingSyncEnd":
+		return "config", true
+	case "FolderSyncEnd":
+		return "folder", true
+	default:
+		return "", false
+	}
 }
 
 func asyncReceiveHandler(handler func(json.RawMessage, *SyncService)) func(json.RawMessage, *SyncService) {

--- a/internal/sync/file_sync.go
+++ b/internal/sync/file_sync.go
@@ -36,6 +36,7 @@ type FileDownloadSession struct {
 	SlotHeld    bool
 	Merging     bool
 	Cancelled   bool
+	PageIndex   *int
 }
 
 type ActiveUpload struct {
@@ -44,6 +45,7 @@ type ActiveUpload struct {
 	SessionID string
 	Cancelled bool
 	SlotHeld  bool
+	PageIndex *int
 }
 
 type fileSyncChunkDownloadMessage struct {
@@ -64,6 +66,7 @@ type fileUploadMessage struct {
 	MTime     int64  `json:"mtime"`
 	SessionID string `json:"sessionId"`
 	ChunkSize int    `json:"chunkSize"`
+	PageIndex *int   `json:"pageIndex,omitempty"`
 }
 
 func tempChunksBaseDir(statePath string) string {
@@ -149,12 +152,14 @@ func handleFileSyncUpdate(data json.RawMessage, s *SyncService) {
 	rp, err := s.resolveVaultPath(msg.Path)
 	if err != nil || s.isVaultFileExcluded(msg.Path) || strings.HasSuffix(strings.ToLower(msg.Path), ".md") {
 		s.incrementCompleted("file")
+		s.completeSyncPage("file", msg.PageIndex)
 		return
 	}
 	if s.cfg.BinarySyncLimitEnabled && msg.Size > binarySyncSizeLimit {
 		log.Printf("[handler] FileSyncUpdate skip large file %q size=%d", rp.Rel, msg.Size)
 		s.updateSyncTime("file", msg.LastTime)
 		s.incrementCompleted("file")
+		s.completeSyncPage("file", msg.PageIndex)
 		return
 	}
 
@@ -181,6 +186,7 @@ func handleFileSyncUpdate(data json.RawMessage, s *SyncService) {
 		session.CTime = msg.CTime
 		session.MTime = msg.MTime
 		session.LastTime = msg.LastTime
+		session.PageIndex = msg.PageIndex
 		session.SlotHeld = true
 		totalChunks := session.TotalChunks
 		s.mu.Unlock()
@@ -197,6 +203,7 @@ func handleFileSyncUpdate(data json.RawMessage, s *SyncService) {
 			CTime:       msg.CTime,
 			MTime:       msg.MTime,
 			LastTime:    msg.LastTime,
+			PageIndex:   msg.PageIndex,
 			Size:        msg.Size,
 			Received:    make(map[uint32]struct{}),
 			SlotHeld:    true,
@@ -218,6 +225,7 @@ func handleFileSyncUpdate(data json.RawMessage, s *SyncService) {
 		}
 		s.mu.Unlock()
 		log.Printf("[handler] FileSyncUpdate request chunk %q: %v", rp.Rel, err)
+		s.completeSyncPage("file", msg.PageIndex)
 		return
 	}
 	s.incrementCompleted("file")
@@ -251,6 +259,7 @@ func handleFileSyncChunkDownload(data json.RawMessage, s *SyncService) {
 			CTime:       msg.CTime,
 			MTime:       msg.MTime,
 			LastTime:    temp.LastTime,
+			PageIndex:   temp.PageIndex,
 			SessionID:   msg.SessionID,
 			TotalChunks: msg.TotalChunks,
 			Size:        msg.Size,
@@ -306,33 +315,34 @@ func handleFileUpload(data json.RawMessage, s *SyncService) {
 		return
 	}
 	if s.cfg.ReadOnlySyncEnabled {
-		s.incrementCompleted("file")
+		s.incrementCompletedPage("file", msg.PageIndex)
 		return
 	}
 	rp, err := s.resolveVaultPath(msg.Path)
 	if err != nil || s.isVaultFileExcluded(msg.Path) || strings.HasSuffix(strings.ToLower(msg.Path), ".md") {
-		s.incrementCompleted("file")
+		s.incrementCompletedPage("file", msg.PageIndex)
 		return
 	}
 	info, err := os.Stat(rp.Abs)
 	if err != nil {
-		s.incrementCompleted("file")
+		s.incrementCompletedPage("file", msg.PageIndex)
 		return
 	}
 	if s.cfg.BinarySyncLimitEnabled && info.Size() > binarySyncSizeLimit {
 		log.Printf("[handler] FileUpload skip large file %q size=%d", rp.Rel, info.Size())
-		s.incrementCompleted("file")
+		s.incrementCompletedPage("file", msg.PageIndex)
 		return
 	}
 
 	s.mu.Lock()
 	upload := s.activeUploads[rp.Rel]
 	if upload == nil {
-		upload = &ActiveUpload{Path: rp.Rel, PathHash: msg.PathHash}
+		upload = &ActiveUpload{Path: rp.Rel, PathHash: msg.PathHash, PageIndex: msg.PageIndex}
 		s.activeUploads[rp.Rel] = upload
 	}
 	upload.SessionID = msg.SessionID
 	upload.PathHash = msg.PathHash
+	upload.PageIndex = msg.PageIndex
 	slotHeld := upload.SlotHeld
 	s.mu.Unlock()
 	if !slotHeld {
@@ -353,10 +363,10 @@ func handleFileSyncDelete(data json.RawMessage, s *SyncService) {
 	var msg receivePathMessage
 	if err := json.Unmarshal(data, &msg); err != nil {
 		log.Printf("[handler] FileSyncDelete parse: %v", err)
-		s.incrementCompleted("file")
+		s.incrementCompletedPage("file", msg.PageIndex)
 		return
 	}
-	defer s.incrementCompleted("file")
+	defer s.incrementCompletedPage("file", msg.PageIndex)
 	s.updateSyncTime("file", msg.LastTime)
 	rp, err := s.resolveVaultPath(msg.Path)
 	if err != nil || s.isVaultFileExcluded(msg.Path) || strings.HasSuffix(strings.ToLower(msg.Path), ".md") {
@@ -385,7 +395,7 @@ func handleFileSyncMtime(data json.RawMessage, s *SyncService) {
 		s.incrementCompleted("file")
 		return
 	}
-	defer s.incrementCompleted("file")
+	defer s.incrementCompletedPage("file", msg.PageIndex)
 	s.updateSyncTime("file", msg.LastTime)
 	rp, err := s.resolveVaultPath(msg.Path)
 	if err != nil || s.isVaultFileExcluded(msg.Path) {
@@ -421,7 +431,7 @@ func handleFileSyncRename(data json.RawMessage, s *SyncService) {
 		s.incrementCompleted("file")
 		return
 	}
-	defer s.incrementCompleted("file")
+	defer s.incrementCompletedPage("file", msg.PageIndex)
 	s.updateSyncTime("file", msg.LastTime)
 	oldRP, oldErr := s.resolveVaultPath(msg.OldPath)
 	newRP, newErr := s.resolveVaultPath(msg.Path)
@@ -650,6 +660,9 @@ func (s *SyncService) abortDownloadSession(sessionID, reason string) {
 	if session != nil && session.TempDir != "" {
 		_ = os.RemoveAll(session.TempDir)
 	}
+	if session != nil {
+		s.completeSyncPage("file", session.PageIndex)
+	}
 	log.Printf("[handler] abort download session=%s reason=%s", sessionID, reason)
 }
 
@@ -743,6 +756,7 @@ func (s *SyncService) mergeDownloadSession(session *FileDownloadSession) {
 	s.mu.Unlock()
 	_ = os.RemoveAll(session.TempDir)
 	s.saveStateLog("FileDownloadComplete")
+	s.completeSyncPage("file", session.PageIndex)
 }
 
 func (s *SyncService) runFileUpload(rp resolvedPath, msg fileUploadMessage, upload *ActiveUpload, chunkSize int) {
@@ -752,7 +766,7 @@ func (s *SyncService) runFileUpload(rp resolvedPath, msg fileUploadMessage, uplo
 		s.releaseFailedUploadSlot(upload)
 		return
 	}
-	contentHash := h.Content(content)
+	contentHash := h.FileContent(content)
 	totalChunks := 1
 	if len(content) > 0 {
 		totalChunks = (len(content) + chunkSize - 1) / chunkSize
@@ -814,8 +828,8 @@ func (s *SyncService) runFileUpload(rp resolvedPath, msg fileUploadMessage, uplo
 
 	s.mu.Lock()
 	delete(s.activeUploads, rp.Rel)
-	s.fileSyncTasks.Completed++
 	s.mu.Unlock()
+	s.incrementCompletedPage("file", msg.PageIndex)
 }
 
 func (s *SyncService) uploadStartChunk(pathHash, sessionID, contentHash string, totalChunks int) int {
@@ -846,12 +860,15 @@ func (s *SyncService) releaseFailedUploadSlot(upload *ActiveUpload) {
 		s.concurrency.ReleaseSlot(upload.Path)
 	}
 	s.mu.Unlock()
+	s.completeSyncPage("file", upload.PageIndex)
 }
 
 func (s *SyncService) cancelUpload(rel string) {
 	s.mu.Lock()
 	upload := s.activeUploads[rel]
+	var pageIndex *int
 	if upload != nil {
+		pageIndex = upload.PageIndex
 		upload.Cancelled = true
 		if upload.SlotHeld {
 			upload.SlotHeld = false
@@ -866,6 +883,7 @@ func (s *SyncService) cancelUpload(rel string) {
 	delete(s.st.PendingUploadHashes, rel)
 	s.mu.Unlock()
 	s.saveStateLog("FileUploadCancel")
+	s.completeSyncPage("file", pageIndex)
 }
 
 func (s *SyncService) SendFileUploadCheck(raw string) error {

--- a/internal/sync/file_sync_test.go
+++ b/internal/sync/file_sync_test.go
@@ -465,11 +465,17 @@ func TestHandleFileUploadSendFailureKeepsActiveUploadForTimeout(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "fail.bin"), []byte("abcdef"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	pageIndex := 0
+	svc.syncPages["file"] = &syncPageTracker{
+		Context: "ctx",
+		Pages:   map[int]*syncPage{0: {TotalCount: 1}},
+	}
 	msg, _ := json.Marshal(fileUploadMessage{
 		Path:      "fail.bin",
 		PathHash:  h.Path("fail.bin"),
 		SessionID: testSessionID,
 		ChunkSize: 3,
+		PageIndex: &pageIndex,
 	})
 	handleFileUpload(msg, svc)
 	waitFor(t, func() bool {
@@ -484,6 +490,14 @@ func TestHandleFileUploadSendFailureKeepsActiveUploadForTimeout(t *testing.T) {
 	svc.mu.Unlock()
 	if completed != 0 || !active {
 		t.Fatalf("send failure completed=%d active=%v, want completed 0 and active true", completed, active)
+	}
+	svc.mu.Lock()
+	tracker := svc.syncPages["file"]
+	watermark := tracker.AckWatermark
+	remainingPages := len(tracker.Pages)
+	svc.mu.Unlock()
+	if watermark != 1 || remainingPages != 0 {
+		t.Fatalf("send failure page state = watermark %d, pages %d; want 1/0", watermark, remainingPages)
 	}
 }
 

--- a/internal/sync/folder_sync.go
+++ b/internal/sync/folder_sync.go
@@ -9,10 +9,11 @@ import (
 )
 
 type folderSyncMsgData struct {
-	Path     string `json:"path"`
-	MTime    int64  `json:"mtime"`
-	LastTime int64  `json:"lastTime"`
-	PathHash string `json:"pathHash"`
+	Path      string `json:"path"`
+	MTime     int64  `json:"mtime"`
+	LastTime  int64  `json:"lastTime"`
+	PathHash  string `json:"pathHash"`
+	PageIndex *int   `json:"pageIndex,omitempty"`
 }
 
 // handleFolderSyncEnd sets the folderSyncTasks need counts (BEFORE setting the flag).
@@ -54,17 +55,11 @@ func handleFolderSyncModify(data json.RawMessage, s *SyncService) {
 	var msg folderSyncMsgData
 	if err := json.Unmarshal(data, &msg); err != nil {
 		log.Printf("[handler] FolderSyncModify parse: %v", err)
-		s.mu.Lock()
-		s.folderSyncTasks.Completed++
-		s.mu.Unlock()
+		s.incrementCompleted("folder")
 		return
 	}
 
-	defer func() {
-		s.mu.Lock()
-		s.folderSyncTasks.Completed++
-		s.mu.Unlock()
-	}()
+	defer s.incrementCompletedPage("folder", msg.PageIndex)
 	s.updateSyncTime("folder", msg.LastTime)
 
 	if s.isFolderPathExcluded(msg.Path) {
@@ -99,17 +94,11 @@ func handleFolderSyncDelete(data json.RawMessage, s *SyncService) {
 	var msg folderSyncMsgData
 	if err := json.Unmarshal(data, &msg); err != nil {
 		log.Printf("[handler] FolderSyncDelete parse: %v", err)
-		s.mu.Lock()
-		s.folderSyncTasks.Completed++
-		s.mu.Unlock()
+		s.incrementCompleted("folder")
 		return
 	}
 
-	defer func() {
-		s.mu.Lock()
-		s.folderSyncTasks.Completed++
-		s.mu.Unlock()
-	}()
+	defer s.incrementCompletedPage("folder", msg.PageIndex)
 	s.updateSyncTime("folder", msg.LastTime)
 
 	if s.isFolderPathExcluded(msg.Path) {
@@ -162,7 +151,7 @@ func handleFolderSyncRename(data json.RawMessage, s *SyncService) {
 		s.incrementCompleted("folder")
 		return
 	}
-	defer s.incrementCompleted("folder")
+	defer s.incrementCompletedPage("folder", msg.PageIndex)
 	s.updateSyncTime("folder", msg.LastTime)
 	oldRP, oldErr := s.resolveVaultPath(msg.OldPath)
 	newRP, newErr := s.resolveVaultPath(msg.Path)

--- a/internal/sync/note_sync.go
+++ b/internal/sync/note_sync.go
@@ -45,6 +45,9 @@ func handleNoteSyncEnd(data json.RawMessage, s *SyncService) {
 	s.mu.Lock()
 	// Commit scanned hashes (only if newer than existing entry).
 	for path, entry := range scanned {
+		if _, pending := s.pendingNoteModifies[path]; pending {
+			continue
+		}
 		if existing, ok := s.st.FileHashMap[path]; !ok || existing.MTime <= entry.MTime {
 			s.st.FileHashMap[path] = entry
 		}
@@ -67,8 +70,7 @@ func handleNoteSyncModify(data json.RawMessage, s *SyncService) {
 		s.incrementCompleted("note")
 		return
 	}
-	defer s.incrementCompleted("note")
-	s.updateSyncTime("note", msg.LastTime)
+	defer s.incrementCompletedPage("note", msg.PageIndex)
 
 	rp, err := s.resolveVaultPath(msg.Path)
 	if err != nil || !strings.HasSuffix(strings.ToLower(msg.Path), ".md") || s.isVaultFileExcluded(msg.Path) {
@@ -89,6 +91,7 @@ func handleNoteSyncModify(data json.RawMessage, s *SyncService) {
 		log.Printf("[handler] NoteSyncModify write %q: %v", rp.Rel, err)
 		return
 	}
+	s.updateSyncTime("note", msg.LastTime)
 	mtime := msg.MTime
 	if mtime > 0 {
 		tm := unixMilli(mtime)
@@ -99,7 +102,7 @@ func handleNoteSyncModify(data json.RawMessage, s *SyncService) {
 		return
 	}
 	if entry.Hash == "" {
-		entry.Hash = h.Content([]byte(msg.Content))
+		entry.Hash = h.Text(msg.Content)
 	}
 	s.mu.Lock()
 	s.st.FileHashMap[rp.Rel] = entry
@@ -114,7 +117,7 @@ func handleNoteSyncNeedPush(data json.RawMessage, s *SyncService) {
 	var msg receivePathMessage
 	if err := json.Unmarshal(data, &msg); err != nil {
 		log.Printf("[handler] NoteSyncNeedPush parse: %v", err)
-		s.incrementCompleted("note")
+		s.incrementCompletedPage("note", msg.PageIndex)
 		return
 	}
 	s.updateSyncTime("note", msg.LastTime)
@@ -123,14 +126,14 @@ func handleNoteSyncNeedPush(data json.RawMessage, s *SyncService) {
 		if err != nil {
 			log.Printf("[handler] NoteSyncNeedPush path %q: %v", msg.Path, err)
 		}
-		s.incrementCompleted("note")
+		s.incrementCompletedPage("note", msg.PageIndex)
 		return
 	}
 	if _, err := os.Stat(rp.Abs); err != nil {
-		s.incrementCompleted("note")
+		s.incrementCompletedPage("note", msg.PageIndex)
 		return
 	}
-	if err := s.sendFileContentModify("NoteModify", rp, s.setPendingNoteModify, func() { s.incrementCompleted("note") }); err != nil {
+	if err := s.sendFileContentModify("NoteModify", rp, s.setPendingNoteModify, func() { s.incrementCompletedPage("note", msg.PageIndex) }); err != nil {
 		log.Printf("[handler] NoteSyncNeedPush send %q: %v", rp.Rel, err)
 	}
 }
@@ -142,7 +145,7 @@ func handleNoteSyncMtime(data json.RawMessage, s *SyncService) {
 		s.incrementCompleted("note")
 		return
 	}
-	defer s.incrementCompleted("note")
+	defer s.incrementCompletedPage("note", msg.PageIndex)
 	s.updateSyncTime("note", msg.LastTime)
 	rp, err := s.resolveVaultPath(msg.Path)
 	if err != nil || s.isVaultFileExcluded(msg.Path) {
@@ -178,7 +181,7 @@ func handleNoteSyncDelete(data json.RawMessage, s *SyncService) {
 		s.incrementCompleted("note")
 		return
 	}
-	defer s.incrementCompleted("note")
+	defer s.incrementCompletedPage("note", msg.PageIndex)
 	s.updateSyncTime("note", msg.LastTime)
 	rp, err := s.resolveVaultPath(msg.Path)
 	if err != nil || s.isVaultFileExcluded(msg.Path) {
@@ -207,7 +210,7 @@ func handleNoteSyncRename(data json.RawMessage, s *SyncService) {
 		s.incrementCompleted("note")
 		return
 	}
-	defer s.incrementCompleted("note")
+	defer s.incrementCompletedPage("note", msg.PageIndex)
 	s.updateSyncTime("note", msg.LastTime)
 	oldRP, oldErr := s.resolveVaultPath(msg.OldPath)
 	newRP, newErr := s.resolveVaultPath(msg.Path)
@@ -232,7 +235,7 @@ func handleNoteSyncRename(data json.RawMessage, s *SyncService) {
 		delete(s.st.FileHashMap, oldRP.Rel)
 		entry.Hash = msg.ContentHash
 		if entry.Hash == "" {
-			entry.Hash = h.Content([]byte{})
+			entry.Hash = h.Text("")
 		}
 		if info, statErr := os.Stat(newRP.Abs); statErr == nil {
 			entry.MTime = info.ModTime().UnixMilli()
@@ -244,7 +247,7 @@ func handleNoteSyncRename(data json.RawMessage, s *SyncService) {
 		return
 	}
 	if msg.ContentHash != "" {
-		if got, _, _, err := h.File(newRP.Abs); err == nil && got == msg.ContentHash {
+		if got, _, _, err := h.TextFile(newRP.Abs); err == nil && got == msg.ContentHash {
 			s.mu.Lock()
 			s.st.FileHashMap[newRP.Rel] = state.FileHashEntry{Hash: got}
 			if info, statErr := os.Stat(newRP.Abs); statErr == nil {
@@ -307,7 +310,7 @@ func handleNoteRenameAck(data json.RawMessage, s *SyncService) {
 	delete(s.st.FileHashMap, item.OldPath)
 	entry.Hash = item.ContentHash
 	if entry.Hash == "" {
-		entry.Hash = h.Content([]byte{})
+		entry.Hash = h.Text("")
 	}
 	if rp, err := s.resolveVaultPath(item.NewPath); err == nil {
 		if info, statErr := os.Stat(rp.Abs); statErr == nil {

--- a/internal/sync/runtime_helpers.go
+++ b/internal/sync/runtime_helpers.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -107,19 +108,22 @@ type receiveContentMessage struct {
 	MTime       int64  `json:"mtime"`
 	Size        int64  `json:"size"`
 	LastTime    int64  `json:"lastTime"`
+	PageIndex   *int   `json:"pageIndex,omitempty"`
 }
 
 type receivePathMessage struct {
-	Path     string `json:"path"`
-	PathHash string `json:"pathHash"`
-	LastTime int64  `json:"lastTime"`
+	Path      string `json:"path"`
+	PathHash  string `json:"pathHash"`
+	LastTime  int64  `json:"lastTime"`
+	PageIndex *int   `json:"pageIndex,omitempty"`
 }
 
 type receiveMtimeMessage struct {
-	Path     string `json:"path"`
-	CTime    int64  `json:"ctime"`
-	MTime    int64  `json:"mtime"`
-	LastTime int64  `json:"lastTime"`
+	Path      string `json:"path"`
+	CTime     int64  `json:"ctime"`
+	MTime     int64  `json:"mtime"`
+	LastTime  int64  `json:"lastTime"`
+	PageIndex *int   `json:"pageIndex,omitempty"`
 }
 
 type receiveRenameMessage struct {
@@ -132,6 +136,7 @@ type receiveRenameMessage struct {
 	MTime       int64  `json:"mtime"`
 	Size        int64  `json:"size"`
 	LastTime    int64  `json:"lastTime"`
+	PageIndex   *int   `json:"pageIndex,omitempty"`
 }
 
 func normalizeSyncPath(raw string) (string, error) {
@@ -324,8 +329,11 @@ func (s *SyncService) updateSyncTime(module string, lastTime int64) {
 }
 
 func (s *SyncService) incrementCompleted(module string) {
+	s.incrementCompletedPage(module, nil)
+}
+
+func (s *SyncService) incrementCompletedPage(module string, pageIndex *int) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	switch module {
 	case "note":
 		s.noteSyncTasks.Completed++
@@ -335,6 +343,153 @@ func (s *SyncService) incrementCompleted(module string) {
 		s.configSyncTasks.Completed++
 	case "folder":
 		s.folderSyncTasks.Completed++
+	}
+	action, payload, send := s.completeSyncPageLocked(module, pageIndex)
+	s.mu.Unlock()
+	if send {
+		if err := s.Send(action, payload); err != nil {
+			log.Printf("[sync] send %s: %v", action, err)
+		} else {
+			log.Printf("[sync] sent %s pageIndex=%v context=%q", action, payload["pageIndex"], payload["context"])
+		}
+	}
+}
+
+func (s *SyncService) completeSyncPage(module string, pageIndex *int) {
+	s.mu.Lock()
+	action, payload, send := s.completeSyncPageLocked(module, pageIndex)
+	s.mu.Unlock()
+	if send {
+		if err := s.Send(action, payload); err != nil {
+			log.Printf("[sync] send %s: %v", action, err)
+		} else {
+			log.Printf("[sync] sent %s pageIndex=%v context=%q", action, payload["pageIndex"], payload["context"])
+		}
+	}
+}
+
+func (s *SyncService) startSyncPaging(module, context string) {
+	s.mu.Lock()
+	total := s.syncTaskTotalLocked(module)
+	if total == 0 {
+		s.mu.Unlock()
+		return
+	}
+	tracker := &syncPageTracker{Context: context, Pages: make(map[int]*syncPage)}
+	s.syncPages[module] = tracker
+	action := syncPageAckAction(module)
+	payload := map[string]interface{}{"context": context, "vault": s.cfg.Vault, "pageIndex": -1}
+	s.mu.Unlock()
+	if err := s.Send(action, payload); err != nil {
+		log.Printf("[sync] send %s: %v", action, err)
+	} else {
+		log.Printf("[sync] sent %s pageIndex=-1 context=%q", action, context)
+	}
+}
+
+func (s *SyncService) handleSyncPage(module string, env Envelope) {
+	var pageData struct {
+		PageIndex  *int `json:"pageIndex"`
+		TotalCount int  `json:"totalCount"`
+		IsLast     bool `json:"isLast"`
+	}
+	if err := json.Unmarshal(env.Data, &pageData); err != nil {
+		log.Printf("[sync] parse %s page: %v", module, err)
+		return
+	}
+	s.mu.Lock()
+	tracker := s.syncPages[module]
+	if tracker == nil {
+		tracker = &syncPageTracker{Context: env.Context, Pages: make(map[int]*syncPage)}
+		s.syncPages[module] = tracker
+	}
+	if env.Context != "" {
+		tracker.Context = env.Context
+	}
+	pageIndex := env.PageIndex
+	if pageData.PageIndex != nil {
+		pageIndex = *pageData.PageIndex
+	}
+	if _, exists := tracker.Pages[pageIndex]; !exists {
+		tracker.Pages[pageIndex] = &syncPage{TotalCount: pageData.TotalCount, IsLast: pageData.IsLast}
+		log.Printf("[sync] registered %s page=%d total=%d last=%t context=%q", module, pageIndex, pageData.TotalCount, pageData.IsLast, tracker.Context)
+	}
+	action, payload, send := s.advanceSyncPageAckLocked(module, tracker)
+	s.mu.Unlock()
+	if send {
+		if err := s.Send(action, payload); err != nil {
+			log.Printf("[sync] send %s: %v", action, err)
+		} else {
+			log.Printf("[sync] sent %s pageIndex=%d context=%q", action, payload["pageIndex"], payload["context"])
+		}
+	}
+}
+
+func (s *SyncService) completeSyncPageLocked(module string, pageIndex *int) (string, map[string]interface{}, bool) {
+	if pageIndex == nil {
+		return "", nil, false
+	}
+	tracker := s.syncPages[module]
+	if tracker == nil {
+		return "", nil, false
+	}
+	page := tracker.Pages[*pageIndex]
+	if page == nil || page.CompletedCount >= page.TotalCount {
+		return "", nil, false
+	}
+	page.CompletedCount++
+	if page.CompletedCount == page.TotalCount {
+		log.Printf("[sync] completed %s page=%d total=%d last=%t", module, *pageIndex, page.TotalCount, page.IsLast)
+	}
+	return s.advanceSyncPageAckLocked(module, tracker)
+}
+
+func (s *SyncService) advanceSyncPageAckLocked(module string, tracker *syncPageTracker) (string, map[string]interface{}, bool) {
+	highest := -1
+	for {
+		page := tracker.Pages[tracker.AckWatermark]
+		if page == nil || page.IsLast || page.CompletedCount < page.TotalCount {
+			break
+		}
+		highest = tracker.AckWatermark
+		delete(tracker.Pages, tracker.AckWatermark)
+		tracker.AckWatermark++
+	}
+	if highest < 0 {
+		return "", nil, false
+	}
+	return syncPageAckAction(module), map[string]interface{}{
+		"context": tracker.Context, "vault": s.cfg.Vault, "pageIndex": highest,
+	}, true
+}
+
+func (s *SyncService) syncTaskTotalLocked(module string) int {
+	var tasks SyncTaskCounter
+	switch module {
+	case "note":
+		tasks = s.noteSyncTasks
+	case "file":
+		tasks = s.fileSyncTasks
+	case "config":
+		tasks = s.configSyncTasks
+	case "folder":
+		tasks = s.folderSyncTasks
+	}
+	return tasks.NeedUpload + tasks.NeedModify + tasks.NeedSyncMtime + tasks.NeedDelete
+}
+
+func syncPageAckAction(module string) string {
+	switch module {
+	case "note":
+		return "NoteSyncPageAck"
+	case "file":
+		return "FileSyncPageAck"
+	case "config":
+		return "SettingSyncPageAck"
+	case "folder":
+		return "FolderSyncPageAck"
+	default:
+		return ""
 	}
 }
 
@@ -398,7 +553,7 @@ func (s *SyncService) sendFileContentModify(action string, rp resolvedPath, pend
 	if err != nil {
 		return err
 	}
-	hash := h.Content(content)
+	hash := h.Text(string(content))
 	info, err := os.Stat(rp.Abs)
 	if err != nil {
 		return err
@@ -436,7 +591,11 @@ func (s *SyncService) sendRename(action, oldRaw, newRaw string, pending func(str
 	}
 	contentHash := ""
 	if b, readErr := os.ReadFile(newRP.Abs); readErr == nil {
-		contentHash = h.Content(b)
+		if action == "FileRename" {
+			contentHash = h.Content(b)
+		} else {
+			contentHash = h.Text(string(b))
+		}
 	} else {
 		s.mu.Lock()
 		if entry, ok := s.st.FileHashMap[oldRP.Rel]; ok {

--- a/internal/sync/startup.go
+++ b/internal/sync/startup.go
@@ -130,18 +130,14 @@ func (s *SyncService) handleSync(isLoadLastTime bool) {
 	s.fileSyncTasks = SyncTaskCounter{}
 	s.configSyncTasks = SyncTaskCounter{}
 	s.folderSyncTasks = SyncTaskCounter{}
+	s.syncPages = make(map[string]*syncPageTracker)
 	s.mu.Unlock()
 
 	go func() {
-		defer func() {
-			s.mu.Lock()
-			s.isSyncing = false
-			s.mu.Unlock()
-		}()
-
 		result, err := s.scanVault(isLoadLastTime)
 		if err != nil {
 			log.Printf("[sync] vault scan failed: %v", err)
+			s.onSyncFailed(fmt.Errorf("scan vault: %w", err))
 			return
 		}
 
@@ -215,7 +211,7 @@ func (s *SyncService) sendSyncRequests(result *scanResult, context string, isLoa
 	// Step 3: NoteSync
 	if err := s.Send("NoteSync", buildNoteSyncPayload(s.cfg.Vault, lastNoteTime, context, result, s.cfg.OfflineDeleteSyncEnabled)); err != nil {
 		log.Printf("[sync] send NoteSync: %v", err)
-	} else {
+	} else if !s.cfg.ReadOnlySyncEnabled {
 		s.mu.Lock()
 		for _, n := range result.notes {
 			s.pendingNoteModifies[n.Path] = n.ContentHash
@@ -247,7 +243,7 @@ func (s *SyncService) sendSyncRequests(result *scanResult, context string, isLoa
 	if s.cfg.ConfigSyncEnabled {
 		if err := s.Send("SettingSync", buildSettingSyncPayload(s.cfg.Vault, lastConfigTime, context, result, s.cfg.OfflineDeleteSyncEnabled)); err != nil {
 			log.Printf("[sync] send SettingSync: %v", err)
-		} else {
+		} else if !s.cfg.ReadOnlySyncEnabled {
 			s.mu.Lock()
 			for _, c := range result.configs {
 				s.pendingConfigModifies[c.Path] = c.ContentHash
@@ -350,22 +346,60 @@ func (s *SyncService) runCheckSyncCompletion(wasInitSync bool) {
 	if timeout == 0 {
 		timeout = 30 * time.Second
 	}
-	deadline := time.Now().Add(timeout)
+	lastProgress := s.syncProgressSnapshot()
+	lastProgressAt := time.Now()
 	ticker := time.NewTicker(200 * time.Millisecond)
 	defer ticker.Stop()
 	for range ticker.C {
-		done := s.isSyncComplete()
-		if done || time.Now().After(deadline) {
-			if !done {
-				log.Printf("[sync] checkSyncCompletion: timeout, forcing completion")
-				s.cleanupActiveFileTransfersOnTimeout()
-			} else {
-				log.Printf("[sync] checkSyncCompletion: sync complete")
-			}
+		if s.isSyncComplete() {
+			log.Printf("[sync] checkSyncCompletion: sync complete")
 			s.onSyncComplete(wasInitSync)
 			return
 		}
+		progress := s.syncProgressSnapshot()
+		if progress != lastProgress {
+			lastProgress = progress
+			lastProgressAt = time.Now()
+			continue
+		}
+		if time.Since(lastProgressAt) >= timeout {
+			log.Printf("[sync] checkSyncCompletion: no progress for %v", timeout)
+			s.cleanupActiveFileTransfersOnTimeout()
+			s.onSyncFailed(fmt.Errorf("sync made no progress for %v", timeout))
+			return
+		}
 	}
+}
+
+type syncProgress struct {
+	tasks          [4]SyncTaskCounter
+	endFlags       [4]bool
+	pageCount      int
+	pageCompleted  int
+	downloads      int
+	receivedChunks int
+	uploads        int
+}
+
+func (s *SyncService) syncProgressSnapshot() syncProgress {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	progress := syncProgress{
+		tasks:     [4]SyncTaskCounter{s.noteSyncTasks, s.fileSyncTasks, s.configSyncTasks, s.folderSyncTasks},
+		endFlags:  [4]bool{s.noteSyncEnd, s.fileSyncEnd, s.configSyncEnd, s.folderSyncEnd},
+		downloads: len(s.fileDownloadSessions),
+		uploads:   len(s.activeUploads),
+	}
+	for _, tracker := range s.syncPages {
+		progress.pageCount += len(tracker.Pages)
+		for _, page := range tracker.Pages {
+			progress.pageCompleted += page.CompletedCount
+		}
+	}
+	for _, session := range s.fileDownloadSessions {
+		progress.receivedChunks += len(session.Received)
+	}
+	return progress
 }
 
 // isSyncComplete returns true when all sync modules have finished.
@@ -424,6 +458,10 @@ func (s *SyncService) cleanupActiveFileTransfersOnTimeout() {
 // onSyncComplete finalizes the sync round: persists IsInitSync when this was the first sync.
 func (s *SyncService) onSyncComplete(wasInitSync bool) {
 	log.Printf("[sync] sync round complete (wasInitSync=%v)", wasInitSync)
+	s.mu.Lock()
+	s.isSyncing = false
+	s.syncErr = nil
+	s.mu.Unlock()
 	if !wasInitSync {
 		s.mu.Lock()
 		s.st.IsInitSync = true
@@ -432,6 +470,14 @@ func (s *SyncService) onSyncComplete(wasInitSync bool) {
 			log.Printf("[sync] persist IsInitSync: %v", err)
 		}
 	}
+	s.syncDoneOnce.Do(func() { close(s.syncDoneCh) })
+}
+
+func (s *SyncService) onSyncFailed(err error) {
+	s.mu.Lock()
+	s.isSyncing = false
+	s.syncErr = err
+	s.mu.Unlock()
 	s.syncDoneOnce.Do(func() { close(s.syncDoneCh) })
 }
 
@@ -532,7 +578,7 @@ func (s *SyncService) scanVault(isLoadLastTime bool) (*scanResult, error) {
 					}
 				}
 			}
-			contentHash, fromCache, hashErr := h.FileCached(absPath, fileHashMapToCache(fileHashMap[relPath]))
+			contentHash, fromCache, hashErr := h.TextFileCached(absPath, fileHashMapToCache(fileHashMap[relPath]))
 			if hashErr != nil {
 				log.Printf("[scan] hash note %q: %v", relPath, hashErr)
 				return nil
@@ -699,7 +745,7 @@ func (s *SyncService) scanConfigs(vaultPath string, configHashMap map[string]sta
 			}
 		}
 
-		contentHash, fromCache, hashErr := h.FileCached(absPath, fileHashMapToCache(configHashMap[relPath]))
+		contentHash, fromCache, hashErr := h.TextFileCached(absPath, fileHashMapToCache(configHashMap[relPath]))
 		if hashErr != nil {
 			log.Printf("[scan] hash config %q: %v", relPath, hashErr)
 			return

--- a/internal/sync/startup_test.go
+++ b/internal/sync/startup_test.go
@@ -320,6 +320,7 @@ func TestHandleSync_ResetsFlags(t *testing.T) {
 	svc.noteSyncEnd = true
 	svc.fileSyncEnd = true
 	svc.noteSyncTasks = SyncTaskCounter{Completed: 5}
+	svc.syncPages["note"] = &syncPageTracker{Context: "stale", Pages: map[int]*syncPage{0: {TotalCount: 1}}}
 	svc.handleSync(false)
 	time.Sleep(20 * time.Millisecond)
 	svc.mu.Lock()
@@ -328,6 +329,9 @@ func TestHandleSync_ResetsFlags(t *testing.T) {
 	}
 	if svc.noteSyncTasks.Completed != 0 {
 		t.Error("noteSyncTasks should be reset by handleSync")
+	}
+	if len(svc.syncPages) != 0 {
+		t.Errorf("syncPages should be reset by handleSync: %+v", svc.syncPages)
 	}
 	svc.mu.Unlock()
 }
@@ -563,9 +567,9 @@ func TestSaveState_WritesAndLoads(t *testing.T) {
 	}
 }
 
-// ---- checkSyncCompletion timeout → onSyncComplete ----
+// ---- checkSyncCompletion lifecycle ----
 
-func TestRunCheckSyncCompletion_TimeoutSetsIsInitSync(t *testing.T) {
+func TestRunCheckSyncCompletion_TimeoutDoesNotSetIsInitSync(t *testing.T) {
 	dir := t.TempDir()
 	statePath := filepath.Join(dir, "state.json")
 	st := state.New()
@@ -573,15 +577,41 @@ func TestRunCheckSyncCompletion_TimeoutSetsIsInitSync(t *testing.T) {
 	svc.statePath = statePath
 	svc.syncTimeout = 30 * time.Millisecond
 
-	// All SyncEnd flags false → never complete → timeout fires onSyncComplete(false)
 	svc.runCheckSyncCompletion(false)
 
-	loaded, err := state.Load(statePath)
-	if err != nil {
-		t.Fatalf("state.Load: %v", err)
+	if svc.st.IsInitSync {
+		t.Error("timeout must not mark initial sync complete")
 	}
-	if !loaded.IsInitSync {
-		t.Error("IsInitSync should be true after timeout with wasInitSync=false")
+	if svc.SyncError() == nil {
+		t.Error("timeout must report a sync error")
+	}
+}
+
+func TestRunCheckSyncCompletion_ProgressExtendsTimeout(t *testing.T) {
+	svc := newTestService(nil, nil, "")
+	svc.syncTimeout = 300 * time.Millisecond
+	svc.noteSyncEnd = true
+	svc.noteSyncTasks.NeedModify = 2
+	svc.fileSyncEnd = true
+	svc.folderSyncEnd = true
+
+	done := make(chan struct{})
+	go func() {
+		svc.runCheckSyncCompletion(true)
+		close(done)
+	}()
+	time.Sleep(150 * time.Millisecond)
+	svc.incrementCompleted("note")
+	time.Sleep(300 * time.Millisecond)
+	svc.incrementCompleted("note")
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("progressing sync did not complete")
+	}
+	if err := svc.SyncError(); err != nil {
+		t.Fatalf("progressing sync timed out: %v", err)
 	}
 }
 
@@ -1244,6 +1274,26 @@ func TestSendSyncRequests_PopulatesPendingModifies(t *testing.T) {
 	}
 	if got := svc.pendingConfigModifies[".obsidian/app.json"]; got != "ch-cfg" {
 		t.Errorf("pendingConfigModifies = %q, want ch-cfg", got)
+	}
+}
+
+func TestSendSyncRequests_ReadOnlyDoesNotPopulatePendingModifies(t *testing.T) {
+	cfg := &config.Config{Vault: "V", ConfigSyncEnabled: true, ReadOnlySyncEnabled: true}
+	svc := newTestService(cfg, nil, "")
+	svc.conn = &fakeWSConn{}
+	svc.folderSyncEnd = true
+
+	r := newScanResult()
+	r.notes = []SnapFile{{Path: "a.md", PathHash: "p", ContentHash: "ch-note"}}
+	r.configs = []SnapFile{{Path: ".obsidian/app.json", PathHash: "p", ContentHash: "ch-cfg"}}
+
+	svc.sendSyncRequests(r, "ctx", false)
+
+	if len(svc.pendingNoteModifies) != 0 || len(svc.st.PendingNoteModifies) != 0 {
+		t.Fatalf("read-only note pending maps = %v / %v, want empty", svc.pendingNoteModifies, svc.st.PendingNoteModifies)
+	}
+	if len(svc.pendingConfigModifies) != 0 || len(svc.st.PendingConfigModifies) != 0 {
+		t.Fatalf("read-only config pending maps = %v / %v, want empty", svc.pendingConfigModifies, svc.st.PendingConfigModifies)
 	}
 }
 

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -329,6 +329,7 @@ func newTestService(cfg *config.Config, st *state.State, statePath string) *Sync
 		scannedConfigHashes:      make(map[string]state.FileHashEntry),
 		concurrency:              NewConcurrencyManager(cfg),
 		pathLocks:                make(map[string]chan struct{}),
+		syncPages:                make(map[string]*syncPageTracker),
 		syncDoneCh:               make(chan struct{}),
 		// Fast timeouts so background goroutines terminate quickly in tests.
 		syncTimeout:     50 * time.Millisecond,
@@ -911,7 +912,7 @@ func TestPathHashPayload(t *testing.T) {
 	if payload["path"] != "notes/a.md" {
 		t.Fatalf("path = %v", payload["path"])
 	}
-	if payload["pathHash"] != "b33a8099b01219568f1660eb604d897c0ac5db4fdd84c142337f129d5a0fca4d" {
+	if payload["pathHash"] != "-115809070" {
 		t.Fatalf("pathHash = %v", payload["pathHash"])
 	}
 }
@@ -966,6 +967,177 @@ func TestHandlerDispatch_InvokesRegistered(t *testing.T) {
 	svc.dispatchText(`NoteSyncEnd|{"code":200,"data":{"lastTime":12345}}`)
 	if got == nil {
 		t.Fatal("handler was not invoked")
+	}
+}
+
+func TestHandlerDispatch_StartsNoteSyncPaging(t *testing.T) {
+	conn := newFakeWSConn()
+	svc := newTestService(&config.Config{Vault: "vault"}, nil, "")
+	svc.conn = conn
+
+	svc.dispatchText(`NoteSyncEnd|{"code":200,"vault":"vault","context":"sync-context","data":{"needUploadCount":1914}}`)
+
+	written := conn.Written()
+	if len(written) != 1 {
+		t.Fatalf("written messages = %v, want initial page ACK", written)
+	}
+	if written[0] != `NoteSyncPageAck|{"context":"sync-context","pageIndex":-1,"vault":"vault"}` {
+		t.Fatalf("initial page ACK = %q", written[0])
+	}
+}
+
+func TestHandlerDispatch_AcksCompletedNoteSyncPage(t *testing.T) {
+	conn := newFakeWSConn()
+	svc := newTestService(&config.Config{Vault: "vault", VaultPath: t.TempDir()}, nil, "")
+	svc.conn = conn
+
+	svc.dispatchText(`NoteSyncPage|{"code":200,"vault":"vault","context":"sync-context","pageIndex":0,"data":{"pageSize":2,"totalCount":2,"isLast":false}}`)
+	svc.dispatchText(`NoteSyncModify|{"code":200,"vault":"vault","data":{"path":"one.md","content":"one","pageIndex":0}}`)
+	if written := conn.Written(); len(written) != 0 {
+		t.Fatalf("ACK sent before page completed: %v", written)
+	}
+	svc.dispatchText(`NoteSyncModify|{"code":200,"vault":"vault","data":{"path":"two.md","content":"two","pageIndex":0}}`)
+
+	written := conn.Written()
+	if len(written) != 1 {
+		t.Fatalf("written messages = %v, want one page ACK", written)
+	}
+	var payload struct {
+		Context   string `json:"context"`
+		Vault     string `json:"vault"`
+		PageIndex int    `json:"pageIndex"`
+	}
+	action, body, ok := strings.Cut(written[0], "|")
+	if !ok {
+		t.Fatalf("written message = %q, want action|payload", written[0])
+	}
+	if action != "NoteSyncPageAck" {
+		t.Fatalf("action = %q, want NoteSyncPageAck", action)
+	}
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		t.Fatalf("decode ACK: %v", err)
+	}
+	if payload.Context != "sync-context" || payload.Vault != "vault" || payload.PageIndex != 0 {
+		t.Fatalf("ACK payload = %+v", payload)
+	}
+}
+
+func TestHandlerDispatch_PropagatesEnvelopePageIndexToWorkItem(t *testing.T) {
+	conn := newFakeWSConn()
+	svc := newTestService(&config.Config{Vault: "vault", VaultPath: t.TempDir()}, nil, "")
+	svc.conn = conn
+
+	svc.dispatchText(`NoteSyncPage|{"code":200,"vault":"vault","context":"sync-context","pageIndex":0,"data":{"pageSize":1,"totalCount":1,"isLast":false}}`)
+	svc.dispatchText(`NoteSyncModify|{"code":200,"vault":"vault","pageIndex":0,"data":{"path":"one.md","content":"one"}}`)
+
+	written := conn.Written()
+	if len(written) != 1 || !strings.HasPrefix(written[0], "NoteSyncPageAck|") {
+		t.Fatalf("page ACK = %v, want NoteSyncPageAck from envelope pageIndex", written)
+	}
+}
+
+func TestHandlerDispatch_UsesActivePageWhenDetailIndexDefaultsToZero(t *testing.T) {
+	conn := newFakeWSConn()
+	svc := newTestService(&config.Config{Vault: "vault", VaultPath: t.TempDir()}, nil, "")
+	svc.conn = conn
+
+	svc.dispatchText(`NoteSyncPage|{"code":200,"vault":"vault","context":"ctx","data":{"pageIndex":0,"totalCount":1,"isLast":false}}`)
+	svc.dispatchText(`NoteSyncModify|{"code":200,"vault":"vault","data":{"path":"one.md","content":"one"}}`)
+	svc.dispatchText(`NoteSyncPage|{"code":200,"vault":"vault","context":"ctx","data":{"pageIndex":1,"totalCount":1,"isLast":false}}`)
+	svc.dispatchText(`NoteSyncModify|{"code":200,"vault":"vault","data":{"path":"two.md","content":"two"}}`)
+
+	written := conn.Written()
+	if len(written) != 2 || !strings.HasSuffix(written[1], `"pageIndex":1,"vault":"vault"}`) {
+		t.Fatalf("page ACKs = %v, want page 1 ACK for unindexed detail", written)
+	}
+}
+
+func TestHandlerDispatch_AcksContiguousPageWatermark(t *testing.T) {
+	conn := newFakeWSConn()
+	svc := newTestService(&config.Config{Vault: "vault", VaultPath: t.TempDir()}, nil, "")
+	svc.conn = conn
+
+	svc.dispatchText(`NoteSyncPage|{"code":200,"vault":"vault","context":"ctx","pageIndex":0,"data":{"totalCount":1,"isLast":false}}`)
+	svc.dispatchText(`NoteSyncPage|{"code":200,"vault":"vault","context":"ctx","pageIndex":1,"data":{"totalCount":1,"isLast":false}}`)
+	svc.dispatchText(`NoteSyncModify|{"code":200,"vault":"vault","data":{"path":"two.md","content":"two","pageIndex":1}}`)
+	if written := conn.Written(); len(written) != 0 {
+		t.Fatalf("ACK skipped incomplete page 0: %v", written)
+	}
+	svc.dispatchText(`NoteSyncModify|{"code":200,"vault":"vault","data":{"path":"one.md","content":"one","pageIndex":0}}`)
+
+	written := conn.Written()
+	if len(written) != 1 || !strings.HasSuffix(written[0], `"pageIndex":1,"vault":"vault"}`) {
+		t.Fatalf("cumulative ACK = %v, want pageIndex 1", written)
+	}
+}
+
+func TestHandlerDispatch_UsesPageMessageIndex(t *testing.T) {
+	conn := newFakeWSConn()
+	svc := newTestService(&config.Config{Vault: "vault", VaultPath: t.TempDir()}, nil, "")
+	svc.conn = conn
+
+	svc.dispatchText(`NoteSyncPage|{"code":200,"vault":"vault","context":"ctx","data":{"pageIndex":1,"totalCount":1,"isLast":false}}`)
+
+	svc.mu.Lock()
+	_, hasPageOne := svc.syncPages["note"].Pages[1]
+	svc.mu.Unlock()
+	if !hasPageOne {
+		t.Fatal("page metadata index from data was not registered")
+	}
+}
+
+func TestHandlerDispatch_AcksEmptyNonFinalPage(t *testing.T) {
+	conn := newFakeWSConn()
+	svc := newTestService(&config.Config{Vault: "vault"}, nil, "")
+	svc.conn = conn
+
+	svc.dispatchText(`NoteSyncPage|{"code":200,"vault":"vault","context":"ctx","pageIndex":0,"data":{"totalCount":0,"isLast":false}}`)
+
+	written := conn.Written()
+	if len(written) != 1 || !strings.HasSuffix(written[0], `"pageIndex":0,"vault":"vault"}`) {
+		t.Fatalf("empty page ACK = %v", written)
+	}
+}
+
+func TestHandlerDispatch_DoesNotAckFinalPage(t *testing.T) {
+	conn := newFakeWSConn()
+	svc := newTestService(&config.Config{Vault: "vault", VaultPath: t.TempDir()}, nil, "")
+	svc.conn = conn
+
+	svc.dispatchText(`NoteSyncPage|{"code":200,"vault":"vault","context":"ctx","pageIndex":0,"data":{"totalCount":1,"isLast":true}}`)
+	svc.dispatchText(`NoteSyncModify|{"code":200,"vault":"vault","data":{"path":"one.md","content":"one","pageIndex":0}}`)
+
+	if written := conn.Written(); len(written) != 0 {
+		t.Fatalf("final page should not be ACKed: %v", written)
+	}
+}
+
+func TestHandlerDispatch_AcksCompletedPagesByModule(t *testing.T) {
+	tests := []struct {
+		name       string
+		pageAction string
+		workAction string
+		workData   string
+		wantAction string
+	}{
+		{name: "file", pageAction: "FileSyncPage", workAction: "FileSyncDelete", workData: `{"path":"missing.bin","pageIndex":0}`, wantAction: "FileSyncPageAck"},
+		{name: "setting", pageAction: "SettingSyncPage", workAction: "SettingSyncDelete", workData: `{"path":".obsidian/app.json","pageIndex":0}`, wantAction: "SettingSyncPageAck"},
+		{name: "folder", pageAction: "FolderSyncPage", workAction: "FolderSyncModify", workData: `{"path":"folder","pageIndex":0}`, wantAction: "FolderSyncPageAck"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := newFakeWSConn()
+			svc := newTestService(&config.Config{Vault: "vault", VaultPath: t.TempDir()}, nil, "")
+			svc.conn = conn
+
+			svc.dispatchText(tt.pageAction + `|{"code":200,"vault":"vault","context":"ctx","pageIndex":0,"data":{"totalCount":1,"isLast":false}}`)
+			svc.dispatchText(tt.workAction + `|{"code":200,"vault":"vault","data":` + tt.workData + `}`)
+
+			written := conn.Written()
+			if len(written) != 1 || !strings.HasPrefix(written[0], tt.wantAction+"|") {
+				t.Fatalf("page ACK = %v, want %s", written, tt.wantAction)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- match the official client/server hash contracts for note text, paths, settings, and sampled large files
- implement context-aware paged sync acknowledgements across notes, files, settings, and folders
- propagate terminal `SyncError` responses and fail stalled sync rounds instead of reporting false completion
- keep read-only sync requests from creating pending upload intent
- serialize concurrent state replacement and make generated Windows test config paths valid YAML

## Why
The headless client could connect to server 3.6 but diverged from the official plugin's hashing and pagination contracts. Large sync rounds could stall or acknowledge pages incorrectly, terminal server errors were not surfaced to callers, and read-only startup scans could leave upload intent behind.

This branch is based directly on current upstream `main` and does not include the changes from PRs #1, #2, or #3.

## Tests
- `go test ./... -count=1`
- `go vet ./...`
- `go build ./...`
- cross-build: Linux amd64, Linux arm64, macOS arm64
- `go mod verify`