### PR TITLE
fix(watcher): re-scan after OS event queue overflow

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -143,6 +143,8 @@ func (f *fakeDaemon) HandleLocalRename(local.RenameEvent) local.Result {
 	return local.Result{}
 }
 
+func (f *fakeDaemon) HandleWatchOverflow() {}
+
 type fakeLocalWatcher struct {
 	closed bool
 }

--- a/internal/local/local.go
+++ b/internal/local/local.go
@@ -31,4 +31,8 @@ type Handler interface {
 	HandleLocalModify(PathEvent) Result
 	HandleLocalDelete(PathEvent) Result
 	HandleLocalRename(RenameEvent) Result
+	// HandleWatchOverflow is called when the OS event queue overflowed and an
+	// unknown number of filesystem events were dropped. The only safe response
+	// is a full re-scan.
+	HandleWatchOverflow()
 }

--- a/internal/sync/local_events.go
+++ b/internal/sync/local_events.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"errors"
+	"log"
 	"os"
 	"strings"
 
@@ -238,4 +239,20 @@ func (s *SyncService) sendLocalModifyForCategory(cat localCategory, rp resolvedP
 	default:
 		return nil
 	}
+}
+
+// HandleWatchOverflow responds to a dropped-event burst from the OS watcher.
+//
+// An overflow means an unknown set of local writes produced no event. Those
+// writes are invisible to the incremental path forever: an incremental scan
+// skips files whose mtime predates the last sync time, so a file written
+// during the overflow window is never re-offered. A full re-scan is the only
+// way to find them, so this deliberately ignores the persisted sync
+// timestamps.
+//
+// handleSync already refuses to start when a sync is in flight or when manual
+// sync mode is set, so this is safe to call at any time.
+func (s *SyncService) HandleWatchOverflow() {
+	log.Printf("[sync] watcher overflow: starting full re-scan to recover dropped events")
+	go s.handleSync(false)
 }

--- a/internal/sync/watch_overflow_test.go
+++ b/internal/sync/watch_overflow_test.go
@@ -1,0 +1,54 @@
+package sync
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/erichll/go-fast-note-sync/internal/config"
+)
+
+// A watcher overflow means an unknown number of filesystem events were dropped,
+// so the only safe response is a full re-scan. These tests pin the sync-side
+// half of that contract: the watcher reports the overflow, the service acts.
+
+func TestHandleWatchOverflowStartsVaultScan(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		API: "http://test.example.com",
+		// Deliberately absent: the scan fails fast, which is a deterministic
+		// signal that a scan was actually attempted.
+		VaultPath: filepath.Join(dir, "no-such-vault"),
+	}
+	svc := newTestService(cfg, nil, filepath.Join(dir, "state.json"))
+
+	svc.HandleWatchOverflow()
+
+	select {
+	case <-svc.SyncComplete():
+	case <-time.After(5 * time.Second):
+		t.Fatal("HandleWatchOverflow did not trigger a vault scan")
+	}
+
+	if svc.SyncError() == nil {
+		t.Fatal("expected the scan of a missing vault to report an error")
+	}
+}
+
+func TestHandleWatchOverflowRespectsManualSyncMode(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		API:               "http://test.example.com",
+		VaultPath:         filepath.Join(dir, "no-such-vault"),
+		ManualSyncEnabled: true,
+	}
+	svc := newTestService(cfg, nil, filepath.Join(dir, "state.json"))
+
+	svc.HandleWatchOverflow()
+
+	select {
+	case <-svc.SyncComplete():
+		t.Fatal("manual sync mode must not be overridden by a watcher overflow")
+	case <-time.After(200 * time.Millisecond):
+	}
+}

--- a/internal/watcher/overflow_test.go
+++ b/internal/watcher/overflow_test.go
@@ -1,0 +1,67 @@
+package watcher
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// When the OS event queue overflows, events are lost silently. inotify reports
+// IN_Q_OVERFLOW and ReadDirectoryChangesW reports a buffer overflow; fsnotify
+// surfaces both as ErrEventOverflow on the Errors channel. The only correct
+// response is a full re-scan, because the dropped events are unrecoverable.
+func TestEventOverflowRequestsFullRescan(t *testing.T) {
+	root := t.TempDir()
+	be := newFakeBackend()
+	h := newRecordingHandler()
+
+	w, err := newWithBackend(root, 5, h, be)
+	if err != nil {
+		t.Fatalf("newWithBackend: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	be.errors <- fsnotify.ErrEventOverflow
+
+	if got := waitEvent(t, h.events); got != "overflow" {
+		t.Fatalf("got %q, want %q", got, "overflow")
+	}
+}
+
+// A wrapped overflow error must still be recognised.
+func TestWrappedEventOverflowRequestsFullRescan(t *testing.T) {
+	root := t.TempDir()
+	be := newFakeBackend()
+	h := newRecordingHandler()
+
+	w, err := newWithBackend(root, 5, h, be)
+	if err != nil {
+		t.Fatalf("newWithBackend: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	be.errors <- errors.New("watching " + root + ": " + fsnotify.ErrEventOverflow.Error())
+	assertNoEvent(t, h.events)
+
+	be.errors <- errors.Join(errors.New("watch failed"), fsnotify.ErrEventOverflow)
+	if got := waitEvent(t, h.events); got != "overflow" {
+		t.Fatalf("got %q, want %q", got, "overflow")
+	}
+}
+
+// Ordinary watcher errors must not trigger a vault-wide re-scan.
+func TestNonOverflowErrorDoesNotRescan(t *testing.T) {
+	root := t.TempDir()
+	be := newFakeBackend()
+	h := newRecordingHandler()
+
+	w, err := newWithBackend(root, 5, h, be)
+	if err != nil {
+		t.Fatalf("newWithBackend: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	be.errors <- errors.New("permission denied")
+	assertNoEvent(t, h.events)
+}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -2,6 +2,7 @@ package watcher
 
 import (
 	"context"
+	"errors"
 	"log"
 	"os"
 	"path/filepath"
@@ -173,6 +174,14 @@ func (w *Watcher) loop() {
 			}
 			if err != nil {
 				log.Printf("[watcher] fsnotify: %v", err)
+				// An overflow means the OS dropped an unknown number of
+				// events. Nothing re-reads them, so without a full re-scan
+				// those writes are stranded until some later unrelated edit
+				// touches the same files.
+				if errors.Is(err, fsnotify.ErrEventOverflow) {
+					log.Printf("[watcher] event queue overflowed, requesting full re-scan")
+					w.handler.HandleWatchOverflow()
+				}
 			}
 		}
 	}

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -94,6 +94,10 @@ func (h *recordingHandler) HandleLocalRename(ev local.RenameEvent) local.Result 
 	return local.Result{Attempted: true}
 }
 
+func (h *recordingHandler) HandleWatchOverflow() {
+	h.events <- "overflow"
+}
+
 func dirSuffix(isDir bool) string {
 	if isDir {
 		return ":dir"


### PR DESCRIPTION
## Problem

`fsnotify` reports a dropped-event condition as `ErrEventOverflow` — inotify's `IN_Q_OVERFLOW` on Linux, and the equivalent `ReadDirectoryChangesW` buffer overrun on Windows. The watcher loop logged it and moved on:

```go
case err, ok := <-w.backend.Errors():
    if !ok {
        return
    }
    if err != nil {
        log.Printf("[watcher] fsnotify: %v", err)
    }
```

Overflow means an unknown number of filesystem events were dropped. Logging it is not a response — the OS is telling us our view of the vault is now wrong, and nothing reconciles it.

Nothing else recovers those events either. `addRecursive` runs at startup and on directory-Create, never on error, and the next process start only does an *incremental* scan, which skips files whose mtime predates the last recorded sync time. So a file written during the overflow window is not merely late — it is stranded until something unrelated touches it again.

This is not theoretical. A batch write of 30 files in a 71 ms burst lost 19 of them, and the failures were a contiguous run in the middle of the batch — the signature of a queue overrunning rather than of any particular file being special. Those 19 files stayed missing until they were repaired by hand.

## Fix

Detect the condition and do the only safe thing: re-scan.

- `local.Handler` gains `HandleWatchOverflow()`, so the watcher can signal the condition without gaining a dependency on the sync service.
- `watcher.loop()` calls it on `errors.Is(err, fsnotify.ErrEventOverflow)`.
- `SyncService.HandleWatchOverflow()` starts a **full** scan (`handleSync(false)`), deliberately ignoring the persisted sync timestamps. An incremental scan is exactly what fails to recover a dropped event, so it would be worse than useless here.

`handleSync` already guards on `isSyncing` and `ManualSyncEnabled`, so an overflow storm collapses into one scan and manual-sync mode is still honoured.

## Tests

`internal/watcher/overflow_test.go`
- overflow error triggers a re-scan request
- a wrapped overflow (`errors.Join`) still triggers it, while a *string-formatted* overflow message does not — `errors.Is` semantics, pinned deliberately so this can't silently regress to substring matching
- an unrelated error does not trigger a re-scan

`internal/sync/watch_overflow_test.go`
- `HandleWatchOverflow` actually starts a vault scan
- manual sync mode is not overridden by an overflow

Both halves are covered; `HandleWatchOverflow` goes from 0% to 100%. I checked the tests fail with the fix reverted rather than trusting that they pass.

## Notes

- `-race` was not run locally (no cgo toolchain on this machine); CI covers it.
- Related but deliberately out of scope: the debouncer allocates one `time.AfterFunc` per unique `kind:rel` key, so a large burst creates unbounded timers. That is a plausible *contributor* to overflow rather than a consequence of it, and it deserves its own change.
