### PR TITLE
fix(config): reject offline_sync_strategy values the server ignores

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,7 +70,7 @@ func Default() *Config {
 		OfflineDeleteSyncEnabled:  false,
 		ReadOnlySyncEnabled:       false,
 		ManualSyncEnabled:         false,
-		OfflineSyncStrategy:       "auto",
+		OfflineSyncStrategy:       "newTimeMerge",
 		SyncUpdateDelay:           500,
 		BinarySyncLimitEnabled:    true,
 		ConcurrencyControlEnabled: true,
@@ -117,7 +117,27 @@ func Load(path string) (*Config, error) {
 	if err := v.Unmarshal(&cfg); err != nil {
 		return nil, fmt.Errorf("unmarshal config: %w", err)
 	}
+	if err := validateOfflineSyncStrategy(cfg.OfflineSyncStrategy); err != nil {
+		return nil, fmt.Errorf("config %s: %w", path, err)
+	}
 	return &cfg, nil
+}
+
+// validateOfflineSyncStrategy rejects any strategy the sync service does not
+// recognize.
+//
+// The server picks its conflict-handling behaviour by matching this value, which
+// the client reports in ClientInfo. An unrecognized value matches none of those
+// branches and is not reported as an error: the server simply skips conflict
+// detection and merging, and the client's content overwrites whatever is stored.
+// Failing here keeps a typo from silently turning off data protection.
+func validateOfflineSyncStrategy(strategy string) error {
+	switch strategy {
+	case "", "manualMerge", "ignoreTimeMerge", "newTimeMerge":
+		return nil
+	}
+	return fmt.Errorf("offline_sync_strategy %q is not recognized by the sync service; "+
+		"valid values are manualMerge, ignoreTimeMerge, newTimeMerge", strategy)
 }
 
 // envRefRegexp matches ${VAR} references where VAR is a POSIX-shell-like identifier.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,8 +15,8 @@ func TestDefault(t *testing.T) {
 	if d.ClientType != DefaultClientType {
 		t.Errorf("Default().ClientType = %q, want DefaultClientType %q", d.ClientType, DefaultClientType)
 	}
-	if d.OfflineSyncStrategy != "auto" {
-		t.Errorf("expected offline_sync_strategy=auto, got %q", d.OfflineSyncStrategy)
+	if d.OfflineSyncStrategy != "newTimeMerge" {
+		t.Errorf("expected offline_sync_strategy=newTimeMerge, got %q", d.OfflineSyncStrategy)
 	}
 	if d.SyncUpdateDelay != 500 {
 		t.Errorf("expected sync_update_delay=500, got %d", d.SyncUpdateDelay)
@@ -62,8 +62,8 @@ func TestWriteDefaultAndLoad(t *testing.T) {
 	if cfg.ClientType != DefaultClientType {
 		t.Errorf("client_type round-trip: got %q, want %q", cfg.ClientType, DefaultClientType)
 	}
-	if cfg.OfflineSyncStrategy != "auto" {
-		t.Errorf("expected auto, got %q", cfg.OfflineSyncStrategy)
+	if cfg.OfflineSyncStrategy != "newTimeMerge" {
+		t.Errorf("expected newTimeMerge, got %q", cfg.OfflineSyncStrategy)
 	}
 	if cfg.SyncUpdateDelay != 500 {
 		t.Errorf("expected 500, got %d", cfg.SyncUpdateDelay)
@@ -127,7 +127,7 @@ max_concurrent_uploads: 5
 	if cfg.ClientType != DefaultClientType {
 		t.Errorf("client_type default: got %q, want %q", cfg.ClientType, DefaultClientType)
 	}
-	if cfg.OfflineSyncStrategy != "auto" {
+	if cfg.OfflineSyncStrategy != "newTimeMerge" {
 		t.Errorf("offline_sync_strategy default: got %q", cfg.OfflineSyncStrategy)
 	}
 }

--- a/internal/config/offline_sync_strategy_test.go
+++ b/internal/config/offline_sync_strategy_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The sync service selects its conflict-handling behaviour from the strategy the
+// client reports in ClientInfo, and it recognizes exactly these values. An
+// unrecognized value is not rejected by the server -- it simply matches none of
+// the branches, which silently disables conflict detection and lets the client
+// overwrite server content. So the client must never send one.
+var serverRecognizedStrategies = []string{"", "manualMerge", "ignoreTimeMerge", "newTimeMerge"}
+
+func TestDefaultOfflineSyncStrategyIsServerRecognized(t *testing.T) {
+	got := Default().OfflineSyncStrategy
+	for _, want := range serverRecognizedStrategies {
+		if got == want {
+			return
+		}
+	}
+	t.Fatalf("default offline_sync_strategy %q is not recognized by the sync service; want one of %v",
+		got, serverRecognizedStrategies)
+}
+
+func TestLoadAcceptsEveryServerRecognizedStrategy(t *testing.T) {
+	for _, strategy := range serverRecognizedStrategies {
+		t.Run("strategy="+strategy, func(t *testing.T) {
+			path := writeStrategyConfig(t, strategy)
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load(%q): %v", strategy, err)
+			}
+			if cfg.OfflineSyncStrategy != strategy {
+				t.Errorf("got %q, want %q", cfg.OfflineSyncStrategy, strategy)
+			}
+		})
+	}
+}
+
+func TestLoadRejectsUnrecognizedOfflineSyncStrategy(t *testing.T) {
+	path := writeStrategyConfig(t, "auto")
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected Load to reject an offline_sync_strategy the server does not recognize")
+	}
+	// The message has to name the setting and the accepted values, otherwise the
+	// operator has no way to tell what went wrong.
+	if !strings.Contains(err.Error(), "offline_sync_strategy") {
+		t.Errorf("error should name the setting, got: %v", err)
+	}
+	for _, want := range []string{"manualMerge", "ignoreTimeMerge", "newTimeMerge"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should list %q as an accepted value, got: %v", want, err)
+		}
+	}
+}
+
+func writeStrategyConfig(t *testing.T, strategy string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	body := "api: \"http://test.example.com\"\noffline_sync_strategy: \"" + strategy + "\"\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}

--- a/internal/sync/handlers_test.go
+++ b/internal/sync/handlers_test.go
@@ -1118,7 +1118,7 @@ func TestM14LocalSendHelpersAndRuntimeHelpers(t *testing.T) {
 		SyncExcludeWhitelist:      []string{"private/ok"},
 		SyncExcludeExtensions:     []string{".tmp"},
 		BinarySyncLimitEnabled:    true,
-		OfflineSyncStrategy:       "auto",
+		OfflineSyncStrategy:       "newTimeMerge",
 		ReadOnlySyncEnabled:       false,
 		ManualSyncEnabled:         false,
 		AutoRedirectEnabled:       false,

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1315,7 +1315,7 @@ func TestSendBinary_NotConnected(t *testing.T) {
 // ---- sendClientInfo content test ----
 
 func TestSendClientInfo_Payload(t *testing.T) {
-	cfg := &config.Config{OfflineSyncStrategy: "auto"}
+	cfg := &config.Config{OfflineSyncStrategy: "newTimeMerge"}
 	svc := newTestService(cfg, nil, "")
 	fc := &fakeWSConn{}
 	svc.mu.Lock()
@@ -1342,7 +1342,7 @@ func TestSendClientInfo_Payload(t *testing.T) {
 		"isLinux":             true,
 		"isDesktop":           false,
 		"isMobile":            false,
-		"offlineSyncStrategy": "auto",
+		"offlineSyncStrategy": "newTimeMerge",
 	}
 	for k, want := range checks {
 		got, ok := payload[k]


### PR DESCRIPTION
## Problem

The client ships `offline_sync_strategy: "auto"`, and the sync service has no such strategy.

The value is client-declared: it travels in `ClientInfo` and the server uses it to decide how to handle conflicting writes. Reading [fast-note-sync-service](https://github.com/haierkeys/fast-note-sync-service) at tag `3.6.0`, `internal/routers/websocket_router/ws_note.go` matches exactly four values — `manualMerge`, `ignoreTimeMerge`, `newTimeMerge`, and `""`.

An unrecognized value isn't rejected. It just fails every comparison, and every one of those comparisons guards a protection:

- The hard conflict check is `if c.OfflineSyncStrategy() == "manualMerge" && ...` — skipped.
- `DiffMergePaths` is only populated for `ignoreTimeMerge`, `manualMerge`, and `newTimeMerge` — so the follow-up `NoteModify` sees `mergeIsNeed == false` and skips the entire merge-and-conflict block.
- What's left is a plain write. The client's content replaces the server's, with no three-way merge and no `.conflict.` file.

`baseHash` is computed, sent, and never read.

It's asymmetric, too. During `doNoteSync`, the strategy `switch` for "server is newer" has cases for `ignoreTimeMerge|manualMerge` and `newTimeMerge|""` and **no `default:`**, so an unknown strategy queues nothing and the client is never told to pull. But "client is newer" queues `NoteSyncNeedPush` unconditionally. Divergence therefore resolves in exactly one direction: the client wins and the server's newer content is gone, with nothing written anywhere to say it happened.

I hit this while tracking down data loss in a multi-device vault. The hosts there had `offline_sync_strategy: ignoreTimeMerge` set explicitly, which is why they produced conflict files instead of silent loss. Anyone running the shipped default is on the unprotected path.

## Fix

- Default to `newTimeMerge` — the behaviour the server applies when no strategy is given, so this changes nothing for a server that was already treating `"auto"` as unmatched, and starts actually requesting the protections.
- Reject unrecognized values in `Load` with an error naming the setting and listing what's accepted.

Empty stays valid, since the server treats it as `newTimeMerge`.

Failing closed matches what `expandEnv` already does in this package for unset `${VAR}` references: a typo should be loud, not silently degraded. A misspelled strategy is worse than a misspelled variable — it disables data protection and looks like it's working.

## Tests

`internal/config/offline_sync_strategy_test.go`
- the default is a value the server recognizes (fails on `"auto"`)
- every recognized value loads, including empty
- an unrecognized value is rejected, and the message names both the setting and the valid values

I checked the rejection test fails with the validation call removed. Existing fixtures that hard-coded `"auto"` are updated.

`gofmt` and `go vet` clean; `internal/config` coverage 91.7% → 92.3%, total 81.7%. `-race` wasn't run locally (no cgo toolchain here); CI covers it.

## Related

The deeper issue is server-side: silently accepting an unrecognized *safety* setting and degrading to no protection. A `default:` case would make this class of bug impossible. Filing that separately against the service repo — this PR just stops the client sending a value that triggers it.
