### PR TITLE
fix(sync): never sync AppleDouble or .DS_Store artifacts

### DIFF
--- a/internal/sync/junk_paths_test.go
+++ b/internal/sync/junk_paths_test.go
@@ -1,0 +1,87 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/erichll/go-fast-note-sync/internal/config"
+)
+
+// AppleDouble sidecars (._Foo) and .DS_Store are macOS filesystem artifacts.
+// They carry no vault content, and the Obsidian plugin has never tracked them,
+// so a client that syncs them creates files the plugin can never remove.
+func TestIsVaultFileExcluded_AppleDouble(t *testing.T) {
+	s := newTestService(nil, nil, "")
+	for _, rel := range []string{
+		"._Note.md",
+		"People/._Steve.md",
+		"Attachments/._image.png",
+		"a/b/c/._deep",
+	} {
+		if !s.isVaultFileExcluded(rel) {
+			t.Errorf("expected AppleDouble path to be excluded: %q", rel)
+		}
+	}
+}
+
+func TestIsVaultFileExcluded_DSStore(t *testing.T) {
+	s := newTestService(nil, nil, "")
+	for _, rel := range []string{
+		".DS_Store",
+		"People/.DS_Store",
+		"People/.ds_store",
+	} {
+		if !s.isVaultFileExcluded(rel) {
+			t.Errorf("expected .DS_Store path to be excluded: %q", rel)
+		}
+	}
+}
+
+// A user whitelist must not be able to resurrect filesystem junk.
+func TestIsVaultFileExcluded_WhitelistDoesNotResurrectJunk(t *testing.T) {
+	cfg := &config.Config{SyncExcludeWhitelist: []string{"Attachments"}}
+	s := newTestService(cfg, nil, "")
+	if !s.isVaultFileExcluded("Attachments/._image.png") {
+		t.Error("whitelist must not un-exclude AppleDouble files")
+	}
+	if !s.isVaultFileExcluded("Attachments/.DS_Store") {
+		t.Error("whitelist must not un-exclude .DS_Store")
+	}
+	if s.isVaultFileExcluded("Attachments/image.png") {
+		t.Error("whitelisted real file should still sync")
+	}
+}
+
+// Names that merely resemble junk must keep syncing.
+func TestIsVaultFileExcluded_LookalikesStillSync(t *testing.T) {
+	s := newTestService(nil, nil, "")
+	for _, rel := range []string{
+		"Templates/_Template.md",
+		"Notes/my._notes.md",
+		"Notes/.DS_Store_notes.md",
+		"Notes/DS_Store.md",
+		"_Inbox/Note.md",
+	} {
+		if s.isVaultFileExcluded(rel) {
+			t.Errorf("expected legitimate path to sync: %q", rel)
+		}
+	}
+}
+
+// AppleDouble files ending in .md are the dangerous case: without a junk rule
+// they are classified as notes and their binary payload is sent as note text.
+func TestLocalCategory_JunkIsSkipped(t *testing.T) {
+	s := newTestService(nil, nil, "")
+	for _, rel := range []string{
+		"._Note.md",
+		"People/._Steve.md",
+		".DS_Store",
+		"People/.DS_Store",
+	} {
+		if got := s.localCategory(rel, false); got != localCategorySkip {
+			t.Errorf("localCategory(%q) = %v, want localCategorySkip", rel, got)
+		}
+	}
+	if got := s.localCategory("People/Steve.md", false); got != localCategoryNote {
+		t.Errorf("localCategory of a real note = %v, want localCategoryNote", got)
+	}
+}

--- a/internal/sync/startup.go
+++ b/internal/sync/startup.go
@@ -866,8 +866,33 @@ func (s *SyncService) scanConfigs(vaultPath string, configHashMap map[string]sta
 	return nil
 }
 
+// isFilesystemJunkPath reports whether a vault-relative path is a macOS
+// filesystem artifact rather than vault content: an AppleDouble sidecar
+// ("._Foo") or a ".DS_Store" index.
+//
+// These must never sync. The Obsidian plugin has never tracked them, so any
+// that this client uploads become files the plugin can never delete, and they
+// accumulate on every other peer. Worse, an AppleDouble sidecar for a note is
+// named "._Note.md": without this rule it is classified as a note and its
+// binary payload is sent to the server as note text.
+func isFilesystemJunkPath(relPath string) bool {
+	base := relPath
+	if i := strings.LastIndexAny(relPath, `/\`); i >= 0 {
+		base = relPath[i+1:]
+	}
+	if strings.HasPrefix(base, "._") {
+		return true
+	}
+	return strings.EqualFold(base, ".DS_Store")
+}
+
 // isVaultFileExcluded returns true if a vault-relative file path should be excluded.
 func (s *SyncService) isVaultFileExcluded(relPath string) bool {
+	// Checked ahead of the whitelist: a user exclusion whitelist must not be
+	// able to resurrect filesystem junk.
+	if isFilesystemJunkPath(relPath) {
+		return true
+	}
 	for _, w := range s.cfg.SyncExcludeWhitelist {
 		if relPath == w || strings.HasPrefix(relPath, w+"/") {
 			return false


### PR DESCRIPTION
## Problem

The client has no built-in ignore rules. Exclusions come only from `sync_exclude_folders`, `sync_exclude_extensions`, and `sync_exclude_whitelist`, all defaulting to empty — so out of the box, macOS filesystem metadata syncs as vault content.

Two kinds, and the first one is the bad one:

**AppleDouble sidecars (`._Name.md`).** These are resource-fork files macOS writes next to real files on filesystems that can't store extended attributes — SMB shares, some NAS mounts, USB drives. They're binary. But `._Note.md` ends in `.md`, and the classification checks extension, so they were being hashed as text and uploaded as *note content*.

**`.DS_Store`.** Finder folder state. Pure noise, changes constantly, means nothing on another machine.

The asymmetry is what made this expensive for me. The Obsidian plugin has never tracked a single `._*` file — I checked its `fileHashMap.json`: 4,396 entries, zero AppleDouble. So these files could only ever be *created* by the Go client and never *removed* by the plugin. 308 of them accumulated on my server and in the vault's git history. When two participants in a sync mesh disagree about what's syncable, the difference doesn't average out; it accretes in whichever direction the stricter client can't clean up.

## Fix

One predicate, checked at a single choke point:

```go
func isFilesystemJunkPath(relPath string) bool {
	base := relPath
	if i := strings.LastIndexAny(relPath, `/\`); i >= 0 {
		base = relPath[i+1:]
	}
	if strings.HasPrefix(base, "._") {
		return true
	}
	return strings.EqualFold(base, ".DS_Store")
}
```

called from the top of `isVaultFileExcluded`.

That one site covers everything, because `isVaultFileExcluded` already runs *before* the `.md` classification in both the scan path (`startup.go`) and the watcher path (`localCategory` in `local_events.go`), and every remote handler routes through it too. No new checks scattered across ~20 call sites.

It's checked ahead of the whitelist deliberately: `sync_exclude_whitelist` exists to re-include user content, and it shouldn't be able to resurrect filesystem metadata. Happy to flip that if you'd rather the whitelist stay absolute.

`.DS_Store` uses `EqualFold` because case-insensitive filesystems will hand you `.ds_store`.

## Tests

`internal/sync/junk_paths_test.go` — five tests: AppleDouble at root and nested, `.DS_Store` in both cases, whitelist can't resurrect junk, and lookalikes still sync (`._` in the middle of a name, files named like `DS_Store` without the dot). Plus `TestLocalCategory_JunkIsSkipped` on the watcher path.

Before the fix, `localCategory("._Note.md")` returned `localCategoryNote` and `localCategory(".DS_Store")` returned `localCategoryFile` — that's the red-phase evidence for both halves.

`gofmt` and `go vet` clean, full suite passes. `-race` not run locally (no cgo toolchain); CI covers it.

## Note on scope

This one's a policy call rather than a pure bug fix, so push back if you disagree with hardcoding. My argument for it being the right default: these files are never vault content under any configuration, the user can't reasonably be expected to know they need excluding, and the cost of getting it wrong is asymmetric — a sidecar synced as note text is silent corruption, while a hardcoded rule that's too aggressive is a visible missing file. If you'd rather it be a default config value than a hardcoded rule, that's an easy change.
