### PR TITLE
fix(sync): recover from a stalled sync round instead of going quiet

### DIFF
--- a/internal/sync/stall_retry_test.go
+++ b/internal/sync/stall_retry_test.go
@@ -1,0 +1,49 @@
+package sync
+
+import (
+	"testing"
+	"time"
+)
+
+// A stalled round used to end the daemon's sync life: isSyncing went false, the
+// error was recorded, and the goroutine returned. Nothing re-triggers a round
+// except authentication or a watcher overflow, so a healthy connection would sit
+// idle forever. Dropping the connection routes the stall into the reconnect path
+// that already exists.
+func TestRunCheckSyncCompletion_StallDropsTheConnectionSoReconnectRetries(t *testing.T) {
+	svc := newTestService(nil, nil, "")
+	svc.syncTimeout = 30 * time.Millisecond
+	conn := newFakeWSConn()
+	svc.conn = conn
+	svc.isRegister = true
+
+	svc.runCheckSyncCompletion(false)
+
+	conn.mu.Lock()
+	closed := conn.closed
+	conn.mu.Unlock()
+	if !closed {
+		t.Error("a stalled sync must drop the connection so the reconnect path runs")
+	}
+	if svc.SyncError() == nil {
+		t.Error("the stall must still be reported")
+	}
+}
+
+// An unregistered service is shutting down; reconnecting would fight the exit.
+func TestRunCheckSyncCompletion_StallLeavesAnUnregisteredServiceAlone(t *testing.T) {
+	svc := newTestService(nil, nil, "")
+	svc.syncTimeout = 30 * time.Millisecond
+	conn := newFakeWSConn()
+	svc.conn = conn
+	svc.isRegister = false
+
+	svc.runCheckSyncCompletion(false)
+
+	conn.mu.Lock()
+	closed := conn.closed
+	conn.mu.Unlock()
+	if closed {
+		t.Error("a deregistered service must not be forced to reconnect")
+	}
+}

--- a/internal/sync/startup.go
+++ b/internal/sync/startup.go
@@ -366,9 +366,26 @@ func (s *SyncService) runCheckSyncCompletion(wasInitSync bool) {
 			log.Printf("[sync] checkSyncCompletion: no progress for %v", timeout)
 			s.cleanupActiveFileTransfersOnTimeout()
 			s.onSyncFailed(fmt.Errorf("sync made no progress for %v", timeout))
+			s.dropConnectionAfterStall()
 			return
 		}
 	}
+}
+
+// dropConnectionAfterStall closes the socket so readLoop unwinds into the
+// reconnect path. Only authentication and watcher overflow start a sync round,
+// so without this a stalled round leaves a healthy connection that never syncs
+// again.
+func (s *SyncService) dropConnectionAfterStall() {
+	s.mu.Lock()
+	conn := s.conn
+	registered := s.isRegister
+	s.mu.Unlock()
+	if conn == nil || !registered {
+		return
+	}
+	log.Printf("[sync] dropping connection after stall to force a fresh sync round")
+	conn.Close() //nolint:errcheck
 }
 
 type syncProgress struct {


### PR DESCRIPTION
A sync round that made no progress recorded the error, cleared `isSyncing` and returned. Only authentication and watcher overflow start a round, so a connection that stalled once stayed healthy, stayed connected, and never synced again -- silent, and indistinguishable from "nothing has changed."

This closes the socket instead. `readLoop` unwinds into the existing bounded reconnect path (15 attempts, exponential backoff to 30 min), which re-authenticates and starts a fresh round. A deregistered service is left alone so shutdown is not fought.

No new retry machinery: the recovery path already existed and was already tested, so the stall is routed into it rather than given a second parallel notion of "try again."

Two tests added in `internal/sync/stall_retry_test.go` covering the stall-drops-connection path and the deregistered-service case. Full suite green against v1.1.0.